### PR TITLE
Fix open issues: remove glide, guard empty saves, add buffer limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ make docker
 ## How It Works
 
 1. Tails the NGINX access log file specified in configuration
-2. Buffers incoming log lines in memory
-3. On a configurable interval, parses the buffered lines using the NGINX log format
+2. Buffers incoming log lines in memory (up to `max_buffer_size`)
+3. On a configurable interval (or when the buffer is full), parses the buffered lines using the NGINX log format
 4. Batch-inserts parsed entries into ClickHouse via the native TCP protocol
 
 ## Configuration
@@ -68,6 +68,7 @@ Configuration is loaded from a YAML file (default: `config/config.yml`). All val
 |---|---|
 | `LOG_PATH` | Path to NGINX access log file |
 | `FLUSH_INTERVAL` | Batch flush interval in seconds |
+| `MAX_BUFFER_SIZE` | Max log lines to buffer before forcing a flush (default: `10000`) |
 | `CLICKHOUSE_HOST` | ClickHouse server hostname |
 | `CLICKHOUSE_PORT` | ClickHouse native TCP port (default: `9000`) |
 | `CLICKHOUSE_DB` | ClickHouse database name |
@@ -86,6 +87,7 @@ settings:
   interval: 5                    # flush interval in seconds
   log_path: /var/log/nginx/access.log
   seek_from_end: false           # start reading from end of file
+  max_buffer_size: 10000         # flush when buffer exceeds this (prevents memory issues)
 
 clickhouse:
   db: metrics

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -24,6 +24,10 @@ var conn driver.Conn
 // Save batch-inserts the parsed log entries into ClickHouse. It reuses an
 // existing connection or establishes a new one based on cfg.
 func Save(cfg *config.Config, logs []gonx.Entry) error {
+	if len(logs) == 0 || len(cfg.ClickHouse.Columns) == 0 {
+		return nil
+	}
+
 	c, err := openConn(cfg)
 	if err != nil {
 		return err

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -68,9 +68,6 @@ func TestBuildRowMissingField(t *testing.T) {
 }
 
 func TestBuildRowEmpty(t *testing.T) {
-	cfg := &config.Config{}
-	_ = cfg // ensure config import is used for consistency
-
 	columns := map[string]string{}
 	keys := []string{}
 
@@ -81,5 +78,28 @@ func TestBuildRowEmpty(t *testing.T) {
 
 	if len(row) != 0 {
 		t.Errorf("expected 0 fields for empty columns, got %d", len(row))
+	}
+}
+
+func TestSaveEmptyLogs(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.ClickHouse.Columns = map[string]string{"RemoteAddr": "remote_addr"}
+
+	err := Save(cfg, nil)
+	if err != nil {
+		t.Errorf("Save with nil logs should return nil, got %v", err)
+	}
+}
+
+func TestSaveEmptyColumns(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.ClickHouse.Columns = map[string]string{}
+
+	parser := gonx.NewParser(`$remote_addr`)
+	entry, _ := parser.ParseString(`192.168.1.1`)
+
+	err := Save(cfg, []gonx.Entry{*entry})
+	if err != nil {
+		t.Errorf("Save with empty columns should return nil, got %v", err)
 	}
 }

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -2,7 +2,8 @@
 settings:
   interval: 5 # in seconds
   log_path: logs/test.log # path to logfile
-  seek_from_end: false # start reading from the lasl line (to prevent duplicates after restart)
+  seek_from_end: false # start reading from the last line (to prevent duplicates after restart)
+  max_buffer_size: 10000 # max log lines to buffer before forcing a flush (prevents memory issues)
 # ClickHouse credentials
 clickhouse:
  db: metrics

--- a/config/config.go
+++ b/config/config.go
@@ -26,9 +26,10 @@ type Config struct {
 
 // SettingsConfig holds general application settings.
 type SettingsConfig struct {
-	Interval    int    `yaml:"interval"`
-	LogPath     string `yaml:"log_path"`
-	SeekFromEnd bool   `yaml:"seek_from_end"`
+	Interval      int    `yaml:"interval"`
+	LogPath       string `yaml:"log_path"`
+	SeekFromEnd   bool   `yaml:"seek_from_end"`
+	MaxBufferSize int    `yaml:"max_buffer_size"`
 }
 
 // ClickHouseConfig holds ClickHouse connection and schema settings.
@@ -94,6 +95,14 @@ func (c *Config) SetEnvVariables() {
 			logrus.Errorf("invalid FLUSH_INTERVAL %q: %v", v, err)
 		}
 		c.Settings.Interval = interval
+	}
+
+	if v := os.Getenv("MAX_BUFFER_SIZE"); v != "" {
+		size, err := strconv.Atoi(v)
+		if err != nil {
+			logrus.Errorf("invalid MAX_BUFFER_SIZE %q: %v", v, err)
+		}
+		c.Settings.MaxBufferSize = size
 	}
 
 	if v := os.Getenv("CLICKHOUSE_HOST"); v != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -146,6 +146,46 @@ func TestSetEnvVariablesPartial(t *testing.T) {
 	}
 }
 
+func TestSetEnvVariablesMaxBufferSize(t *testing.T) {
+	cfg := &Config{}
+	t.Setenv("MAX_BUFFER_SIZE", "5000")
+
+	cfg.SetEnvVariables()
+
+	if cfg.Settings.MaxBufferSize != 5000 {
+		t.Errorf("expected MaxBufferSize=5000, got %d", cfg.Settings.MaxBufferSize)
+	}
+}
+
+func TestReadMaxBufferSize(t *testing.T) {
+	content := `
+settings:
+  interval: 5
+  log_path: /tmp/test.log
+  max_buffer_size: 20000
+clickhouse:
+  db: test
+  table: t
+  host: localhost
+  port: "9000"
+nginx:
+  log_type: main
+  log_format: "$remote_addr"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath = tmpFile
+	cfg := Read()
+
+	if cfg.Settings.MaxBufferSize != 20000 {
+		t.Errorf("expected MaxBufferSize=20000, got %d", cfg.Settings.MaxBufferSize)
+	}
+}
+
 func TestSetEnvVariablesInvalidInterval(t *testing.T) {
 	cfg := &Config{}
 	cfg.Settings.Interval = 5

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,0 @@
-package: mintance/nginx-clickhouse
-import:
-- package: gopkg.in/yaml.v2
-- package: github.com/sirupsen/logrus
-  version: ~1.0.3
-- package: github.com/satyrius/gonx
-- package: github.com/mintance/go-clickhouse

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mintance/nginx-clickhouse/nginx"
 )
 
+const defaultMaxBufferSize = 10000
+
 var (
 	mu   sync.Mutex
 	logs []string
@@ -39,6 +41,10 @@ var (
 func main() {
 	cfg := configParser.Read()
 	cfg.SetEnvVariables()
+
+	if cfg.Settings.MaxBufferSize == 0 {
+		cfg.Settings.MaxBufferSize = defaultMaxBufferSize
+	}
 
 	parser, err := nginx.NewParser(cfg)
 	if err != nil {
@@ -73,35 +79,44 @@ func main() {
 	for line := range t.Lines() {
 		mu.Lock()
 		logs = append(logs, strings.TrimSpace(line.String()))
+		shouldFlush := len(logs) >= cfg.Settings.MaxBufferSize
 		mu.Unlock()
+
+		if shouldFlush {
+			flush(cfg, parser)
+		}
 	}
 }
 
-// flushLoop periodically parses buffered log lines and saves them to ClickHouse.
+// flushLoop periodically flushes buffered log lines to ClickHouse.
 func flushLoop(cfg *configParser.Config, parser *nginx.Parser) {
 	interval := time.Duration(cfg.Settings.Interval) * time.Second
 	for {
 		time.Sleep(interval)
+		flush(cfg, parser)
+	}
+}
 
-		mu.Lock()
-		if len(logs) == 0 {
-			mu.Unlock()
-			continue
-		}
-
-		batch := logs
-		logs = nil
+// flush drains the log buffer and saves entries to ClickHouse.
+func flush(cfg *configParser.Config, parser *nginx.Parser) {
+	mu.Lock()
+	if len(logs) == 0 {
 		mu.Unlock()
+		return
+	}
 
-		logrus.Info("preparing to save ", len(batch), " new log entries")
+	batch := logs
+	logs = nil
+	mu.Unlock()
 
-		entries := nginx.ParseLogs(parser, batch)
-		if err := clickhouse.Save(cfg, entries); err != nil {
-			logrus.Error("can't save logs: ", err)
-			linesNotProcessed.Add(float64(len(batch)))
-		} else {
-			logrus.Info("saved ", len(batch), " new logs")
-			linesProcessed.Add(float64(len(batch)))
-		}
+	logrus.Info("preparing to save ", len(batch), " new log entries")
+
+	entries := nginx.ParseLogs(parser, batch)
+	if err := clickhouse.Save(cfg, entries); err != nil {
+		logrus.Error("can't save logs: ", err)
+		linesNotProcessed.Add(float64(len(batch)))
+	} else {
+		logrus.Info("saved ", len(batch), " new logs")
+		linesProcessed.Add(float64(len(batch)))
 	}
 }


### PR DESCRIPTION
- Remove glide.yaml (Closes #6)
- Closes #7 (gometalinter removed in prior PR)
- Closes #13 (Go modules migration completed in prior PR)
- Guard Save against empty columns/entries to prevent "rows and cols cannot be empty" error (Closes #12)
- Add max_buffer_size config (default: 10000) to prevent unbounded memory growth and service hangs under high log volume (Closes #20). Buffer is flushed early when it exceeds the limit.
- Add tests for empty Save, MaxBufferSize config and env var override
- Update config-sample.yml, README env var table, and config example