### PR TITLE
Feat json logs enrichments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-nginx-clickhouse is a Go microservice that tails NGINX access logs and batch-inserts parsed entries into ClickHouse using the native TCP protocol. It features retry with exponential backoff, optional disk buffering for crash recovery, circuit breaker, structured JSON logging, and Prometheus metrics.
+nginx-clickhouse is a Go microservice that tails NGINX access logs and batch-inserts parsed entries into ClickHouse using the native TCP protocol. It supports both traditional text log formats and JSON access logs (`log_format escape=json`), and provides log enrichment (auto-hostname, environment, service tags, status class derivation). It features retry with exponential backoff, optional disk buffering for crash recovery, circuit breaker, structured JSON logging, and Prometheus metrics.
 
 ## Architecture
 
@@ -10,6 +10,7 @@ nginx-clickhouse is a Go microservice that tails NGINX access logs and batch-ins
 main.go                    → Entry point: tail, buffer, flush loop, graceful shutdown, /healthz
 config/config.go           → YAML config + env var overrides (structured types)
 nginx/nginx.go             → Parses NGINX log lines using gonx (configurable log format)
+nginx/json.go              → Parses NGINX JSON access logs (log_format escape=json) and applies enrichments
 clickhouse/clickhouse.go   → Client struct: connection mgmt, retry-wrapped Save, health check
 retry/retry.go             → Exponential backoff with full jitter
 buffer/buffer.go           → Buffer interface + MemoryBuffer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,11 @@ CI will reject PRs that fail any of these checks.
 ## Testing
 
 ```bash
-go test ./... -v -race              # 47 unit tests across 6 packages
+go test ./... -v -race              # 68 unit tests across 6 packages
 go test ./clickhouse/ -v -tags integration  # Integration tests (requires ClickHouse)
 ```
 
-Packages with tests: retry (7), buffer (10), circuitbreaker (5), clickhouse (8 unit + 4 integration), config (12), nginx (10).
+Packages with tests: retry (7), buffer (10), circuitbreaker (5), clickhouse (15 unit + 4 integration), config (16), nginx (15).
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,59 +2,72 @@
 
 ## Project Overview
 
-nginx-clickhouse is a Go microservice that tails NGINX access logs and batch-inserts parsed entries into ClickHouse using the native TCP protocol. It exposes Prometheus metrics on port 2112.
+nginx-clickhouse is a Go microservice that tails NGINX access logs and batch-inserts parsed entries into ClickHouse using the native TCP protocol. It features retry with exponential backoff, optional disk buffering for crash recovery, circuit breaker, structured JSON logging, and Prometheus metrics.
 
 ## Architecture
 
 ```
-main.go          → Entry point: tails log file, buffers lines, flushes on interval
-config/config.go → YAML config + env var overrides (structured types)
-nginx/nginx.go   → Parses NGINX log lines using gonx (configurable log format)
-clickhouse/clickhouse.go → Batch-saves parsed entries via clickhouse-go/v2 native TCP
+main.go                    → Entry point: tail, buffer, flush loop, graceful shutdown, /healthz
+config/config.go           → YAML config + env var overrides (structured types)
+nginx/nginx.go             → Parses NGINX log lines using gonx (configurable log format)
+clickhouse/clickhouse.go   → Client struct: connection mgmt, retry-wrapped Save, health check
+retry/retry.go             → Exponential backoff with full jitter
+buffer/buffer.go           → Buffer interface + MemoryBuffer
+buffer/disk.go             → DiskBuffer: segment-file append, rotation, crash recovery replay
+circuitbreaker/circuitbreaker.go → Circuit breaker (closed/open/half-open states)
 ```
 
-Flow: tail log → buffer lines (mutex-protected) → periodic flush → parse → batch insert into ClickHouse.
+Flow: startup replay (disk buffer) → tail log → buffer lines (memory or disk) → periodic flush (or buffer-full trigger) → parse → retry-wrapped batch insert → graceful shutdown on SIGTERM.
 
 ## Build & Run
 
 ```bash
 make build                # Static Linux binary (CGO_ENABLED=0)
 make docker               # Docker image (multi-stage, scratch-based)
+make test                 # Unit tests with race detector
+make test-integration     # Integration tests (requires ClickHouse on :9000)
+make lint                 # gofmt + go vet
 go run main.go            # Run locally (reads config/config.yml by default)
-go run main.go -config_path=/path/to/config.yml
 ```
 
 ## Configuration
 
 - YAML config: see `config-sample.yml` for full reference
 - Default ClickHouse port: 9000 (native TCP protocol)
-- All settings can be overridden via env vars: `LOG_PATH`, `FLUSH_INTERVAL`, `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_DB`, `CLICKHOUSE_TABLE`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `NGINX_LOG_TYPE`, `NGINX_LOG_FORMAT`
+- All settings overridable via env vars (see README for full table)
+- Key config sections: settings (interval, buffer, retry, circuit_breaker), clickhouse (connection, columns mapping), nginx (log format)
 
 ## Dependencies
 
 - Go 1.25 (as declared in go.mod)
-- Key libraries: `ClickHouse/clickhouse-go/v2`, `go-tail`, `gonx`, `logrus`, `prometheus/client_golang`, `yaml.v2`
+- `ClickHouse/clickhouse-go/v2` — ClickHouse native TCP client
+- `papertrail/go-tail` — log file tailing
+- `satyrius/gonx` — NGINX log format parsing
+- `sirupsen/logrus` — structured JSON logging
+- `prometheus/client_golang` — Prometheus metrics
+- `gopkg.in/yaml.v2` — YAML config parsing
+- No external deps for retry, buffer, or circuit breaker (pure Go stdlib)
 
 ## Code Conventions
 
 - Standard Go formatting (`gofmt`), verified by `go vet`
-- Follows Google Go Style Guide: doc comments on all exports, `errors.Is` for error comparison, lowercase error strings, proper import grouping (stdlib, third-party, project)
-- Naming: initialisms are ALL_CAPS (`DB` not `Db`), no `Get` prefix on getters
-- Package names: lowercase, single word, with package-level doc comments
-- Error handling: `logrus.Fatal` for startup errors, `logrus.Error` for runtime, `fmt.Errorf` with `%w` for wrapping
-- Concurrency: `sync.Mutex` protects the shared log buffer
-- Modern Go: uses `maps.Keys`, `slices.Collect`, `any`, `errors.Is`
+- Google Go Style Guide: doc comments on all exports, `errors.Is`, lowercase error strings, import grouping (stdlib, third-party, project)
+- Naming: initialisms ALL_CAPS (`DB`), no `Get` prefix, short receiver names
+- Error handling: `logrus.Fatal` for startup, `logrus.WithError(err).Error()` for runtime, `fmt.Errorf("context: %w", err)` for wrapping
+- Logging: JSON formatter, `WithFields` for structured context
+- Concurrency: `sync.Mutex` in buffer, clickhouse client, circuit breaker
+- Modern Go: `maps.Keys`, `slices.Collect`, `slices.Sort`, `any`, `errors.Is`, `math/rand/v2`
 
 ## Testing
 
 ```bash
-go test ./... -v -race              # Unit tests
-go test ./clickhouse/ -v -tags integration  # Integration tests (requires ClickHouse on :9000)
+go test ./... -v -race              # 47 unit tests across 6 packages
+go test ./clickhouse/ -v -tags integration  # Integration tests (requires ClickHouse)
 ```
 
-Unit tests cover config parsing, env var overrides, NGINX field parsing, and ClickHouse row building. Integration tests verify end-to-end batch inserts against a real ClickHouse instance.
+Packages with tests: retry (7), buffer (10), circuitbreaker (5), clickhouse (8 unit + 4 integration), config (12), nginx (10).
 
 ## CI/CD
 
-- `.github/workflows/test.yml` — Unit + integration tests on PRs (ClickHouse service container)
-- `.github/workflows/release.yml` — Auto-release with version bump on PR merge to master
+- `.github/workflows/test.yml` — lint (gofmt + vet), unit tests, integration tests with ClickHouse service container. Runs on PRs to master.
+- `.github/workflows/release.yml` — auto version bump, GitHub release with binary, multi-arch Docker push to Docker Hub + GitHub Container Registry. Runs on PR merge to master.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,19 @@ go run main.go            # Run locally (reads config/config.yml by default)
 - `gopkg.in/yaml.v2` — YAML config parsing
 - No external deps for retry, buffer, or circuit breaker (pure Go stdlib)
 
+## Pre-Push Checklist
+
+Always run before committing or pushing:
+
+```bash
+gofmt -w .                              # Format all files
+test -z "$(gofmt -l . | grep -v '^vendor/')"  # Verify no unformatted files
+go vet ./...                            # Static analysis
+go test ./... -race                     # All tests with race detector
+```
+
+CI will reject PRs that fail any of these checks.
+
 ## Code Conventions
 
 - Standard Go formatting (`gofmt`), verified by `go vet`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Simple NGINX access log parser and transporter to ClickHouse database. Uses the 
 
 - Tails NGINX access logs in real-time
 - Configurable log format parsing via [gonx](https://github.com/satyrius/gonx)
+- **JSON access log support** (`log_format escape=json`) alongside traditional text format
+- **Log enrichment**: auto-hostname, environment, service tags, status class derivation
 - Batch inserts into ClickHouse using the [official Go client](https://github.com/ClickHouse/clickhouse-go) (native TCP, LZ4 compression)
 - **Retry with exponential backoff** and full jitter on ClickHouse failures
 - **Automatic connection recovery** — reconnects transparently after outages
@@ -96,6 +98,10 @@ Configuration is loaded from a YAML file (default: `config/config.yml`). All val
 | `CLICKHOUSE_PASSWORD` | ClickHouse password |
 | `NGINX_LOG_TYPE` | NGINX log format name |
 | `NGINX_LOG_FORMAT` | NGINX log format string |
+| `NGINX_LOG_FORMAT_TYPE` | Log format type: `text` (default) or `json` |
+| `ENRICHMENT_HOSTNAME` | Hostname to add to logs (`auto` for os.Hostname) |
+| `ENRICHMENT_ENVIRONMENT` | Environment tag (e.g., `production`) |
+| `ENRICHMENT_SERVICE` | Service name tag |
 
 ### Full Config Example
 
@@ -140,6 +146,7 @@ clickhouse:
 
 nginx:
   log_type: main
+  log_format_type: text        # "text" (default) or "json"
   log_format: '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"'
 ```
 
@@ -164,6 +171,38 @@ server {
     access_log /var/log/nginx/my-site-access.log main;
 }
 ```
+
+## JSON Access Logs
+
+nginx-clickhouse supports NGINX's native JSON log format (`escape=json`) as an alternative to the traditional text format. JSON logs are more robust — no custom regex parsing, no escaping edge cases.
+
+### 1. Configure NGINX JSON Log Format
+
+In `/etc/nginx/nginx.conf`:
+
+```nginx
+log_format json_combined escape=json
+'{'
+  '"remote_addr":"$remote_addr",'
+  '"request_method":"$request_method",'
+  '"request_uri":"$request_uri",'
+  '"status":$status,'
+  '"body_bytes_sent":$body_bytes_sent,'
+  '"request_time":$request_time,'
+  '"http_referer":"$http_referer",'
+  '"http_user_agent":"$http_user_agent",'
+  '"time_local":"$time_local"'
+'}';
+```
+
+### 2. Set Log Format Type in Config
+
+```yaml
+nginx:
+  log_format_type: json
+```
+
+With JSON format, the `log_type` and `log_format` fields are not needed. The JSON keys in the log are mapped directly via the `columns` config.
 
 ## ClickHouse Setup
 
@@ -264,6 +303,37 @@ States:
 - **Half-open**: after cooldown, one probe flush is attempted. Success closes the circuit; failure re-opens it.
 
 Monitor via `nginx_clickhouse_circuit_breaker_state` (0=closed, 1=open, 2=half-open) and `nginx_clickhouse_circuit_breaker_rejections_total`.
+
+## Enrichments
+
+Enrichments let you automatically inject additional fields into every log entry — hostname, environment, service name, and derived status class — without any changes to the NGINX log format.
+
+Configure enrichments in the `settings` block:
+
+```yaml
+settings:
+  enrichments:
+    hostname: auto
+    environment: production
+    service: my-api
+
+clickhouse:
+  columns:
+    Hostname: _hostname
+    Environment: _environment
+    Service: _service
+    StatusClass: _status_class
+```
+
+Map enrichment fields to ClickHouse columns using the `_` prefix in the column mapping. Available enrichment fields:
+
+| Field | Description |
+|---|---|
+| `_hostname` | Hostname of the machine running nginx-clickhouse (`auto` resolves via `os.Hostname()`, or set a literal value) |
+| `_environment` | Environment tag (e.g., `production`, `staging`) |
+| `_service` | Service name tag |
+| `_status_class` | HTTP status class derived from the `status` field (e.g., `2xx`, `4xx`, `5xx`) |
+| `_extra.<key>` | Arbitrary key-value pairs from the `enrichments.extra` map |
 
 ### Health Check
 

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/satyrius/gonx"
 	"github.com/sirupsen/logrus"
 
 	"github.com/mintance/nginx-clickhouse/config"
@@ -39,7 +38,7 @@ func NewClient(cfg *config.Config) *Client {
 // Save batch-inserts the parsed log entries into ClickHouse. It retries
 // transient failures using exponential backoff based on the retry
 // configuration in cfg.
-func (c *Client) Save(entries []gonx.Entry) error {
+func (c *Client) Save(entries []nginx.LogEntry) error {
 	if len(entries) == 0 || len(c.cfg.ClickHouse.Columns) == 0 {
 		return nil
 	}
@@ -164,7 +163,7 @@ func (c *Client) resetConn() {
 
 // buildRow converts a single parsed log entry into a slice of values ordered
 // by the given column keys.
-func buildRow(keys []string, columns map[string]string, entry gonx.Entry) []any {
+func buildRow(keys []string, columns map[string]string, entry nginx.LogEntry) []any {
 	row := make([]any, 0, len(keys))
 	for _, col := range keys {
 		field := columns[col]

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -205,6 +205,9 @@ func resolveEnrichment(field string, entry nginx.LogEntry, e *config.EnrichmentC
 		if err != nil || len(status) == 0 {
 			return ""
 		}
+		if status[0] < '1' || status[0] > '5' {
+			return ""
+		}
 		return string(status[0]) + "xx"
 	default:
 		if strings.HasPrefix(field, "_extra.") {

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -81,7 +81,7 @@ func (c *Client) Save(entries []nginx.LogEntry) error {
 		}
 
 		for _, entry := range entries {
-			row := buildRow(columns, c.cfg.ClickHouse.Columns, entry)
+			row := buildRow(columns, c.cfg.ClickHouse.Columns, entry, &c.cfg.Settings.Enrichments)
 			if err := batch.Append(row...); err != nil {
 				logrus.WithError(err).Error("append row")
 			}
@@ -162,11 +162,18 @@ func (c *Client) resetConn() {
 }
 
 // buildRow converts a single parsed log entry into a slice of values ordered
-// by the given column keys.
-func buildRow(keys []string, columns map[string]string, entry nginx.LogEntry) []any {
+// by the given column keys. Fields prefixed with "_" are resolved from
+// enrichment configuration rather than from the log entry.
+func buildRow(keys []string, columns map[string]string, entry nginx.LogEntry, enrichments *config.EnrichmentConfig) []any {
 	row := make([]any, 0, len(keys))
 	for _, col := range keys {
 		field := columns[col]
+
+		if strings.HasPrefix(field, "_") {
+			row = append(row, resolveEnrichment(field, entry, enrichments))
+			continue
+		}
+
 		value, err := entry.Field(field)
 		if err != nil {
 			logrus.WithField("field", field).WithError(err).Error("read field")
@@ -176,4 +183,37 @@ func buildRow(keys []string, columns map[string]string, entry nginx.LogEntry) []
 		row = append(row, nginx.ParseField(field, value))
 	}
 	return row
+}
+
+// resolveEnrichment returns the value for a special "_" prefixed field name.
+// Supported fields:
+//   - _hostname: from EnrichmentConfig.Hostname
+//   - _environment: from EnrichmentConfig.Environment
+//   - _service: from EnrichmentConfig.Service
+//   - _status_class: derived from the entry's "status" field (e.g. "200" -> "2xx")
+//   - _extra.<key>: from EnrichmentConfig.Extra map
+func resolveEnrichment(field string, entry nginx.LogEntry, e *config.EnrichmentConfig) any {
+	switch field {
+	case "_hostname":
+		return e.Hostname
+	case "_environment":
+		return e.Environment
+	case "_service":
+		return e.Service
+	case "_status_class":
+		status, err := entry.Field("status")
+		if err != nil || len(status) == 0 {
+			return ""
+		}
+		return string(status[0]) + "xx"
+	default:
+		if strings.HasPrefix(field, "_extra.") {
+			key := strings.TrimPrefix(field, "_extra.")
+			if e.Extra != nil {
+				return e.Extra[key]
+			}
+			return ""
+		}
+		return ""
+	}
 }

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/satyrius/gonx"
 
 	"github.com/mintance/nginx-clickhouse/config"
+	"github.com/mintance/nginx-clickhouse/nginx"
 )
 
 func TestNewClient(t *testing.T) {
@@ -38,7 +39,7 @@ func TestSaveEmptyColumns(t *testing.T) {
 	parser := gonx.NewParser(`$remote_addr`)
 	entry, _ := parser.ParseString(`192.168.1.1`)
 
-	err := client.Save([]gonx.Entry{*entry})
+	err := client.Save([]nginx.LogEntry{entry})
 	if err != nil {
 		t.Errorf("Save with empty columns should return nil, got %v", err)
 	}
@@ -76,7 +77,7 @@ func TestBuildRow(t *testing.T) {
 		t.Fatalf("unexpected error parsing log: %v", err)
 	}
 
-	row := buildRow(keys, columns, *entry)
+	row := buildRow(keys, columns, entry)
 
 	if len(row) != 2 {
 		t.Fatalf("expected 2 fields in row, got %d", len(row))
@@ -115,7 +116,7 @@ func TestBuildRowMissingField(t *testing.T) {
 	parser := gonx.NewParser(`$remote_addr`)
 	entry, _ := parser.ParseString(`192.168.1.1`)
 
-	row := buildRow(keys, columns, *entry)
+	row := buildRow(keys, columns, entry)
 
 	if len(row) != 2 {
 		t.Fatalf("expected 2 fields (with fallback), got %d", len(row))
@@ -129,7 +130,7 @@ func TestBuildRowEmpty(t *testing.T) {
 	parser := gonx.NewParser(`$remote_addr`)
 	entry, _ := parser.ParseString(`192.168.1.1`)
 
-	row := buildRow(keys, columns, *entry)
+	row := buildRow(keys, columns, entry)
 
 	if len(row) != 0 {
 		t.Errorf("expected 0 fields for empty columns, got %d", len(row))

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -208,6 +208,37 @@ func TestBuildRowStatusClassVariants(t *testing.T) {
 	}
 }
 
+func TestBuildRowStatusClassInvalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{"non-numeric", "OK"},
+		{"zero prefix", "099"},
+		{"six prefix", "600"},
+		{"empty", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			columns := map[string]string{"StatusClass": "_status_class"}
+			keys := []string{"StatusClass"}
+
+			parser := gonx.NewParser(`$status`)
+			entry, _ := parser.ParseString(tt.status)
+
+			row := buildRow(keys, columns, entry, &config.EnrichmentConfig{})
+
+			if len(row) != 1 {
+				t.Fatalf("expected 1 field, got %d", len(row))
+			}
+			if row[0] != "" {
+				t.Errorf("expected empty string for invalid status %q, got %v", tt.status, row[0])
+			}
+		})
+	}
+}
+
 func TestBuildRowExtraEnrichment(t *testing.T) {
 	columns := map[string]string{
 		"MyTag": "_extra.my_tag",

--- a/clickhouse/clickhouse_test.go
+++ b/clickhouse/clickhouse_test.go
@@ -77,7 +77,7 @@ func TestBuildRow(t *testing.T) {
 		t.Fatalf("unexpected error parsing log: %v", err)
 	}
 
-	row := buildRow(keys, columns, entry)
+	row := buildRow(keys, columns, entry, &config.EnrichmentConfig{})
 
 	if len(row) != 2 {
 		t.Fatalf("expected 2 fields in row, got %d", len(row))
@@ -116,7 +116,7 @@ func TestBuildRowMissingField(t *testing.T) {
 	parser := gonx.NewParser(`$remote_addr`)
 	entry, _ := parser.ParseString(`192.168.1.1`)
 
-	row := buildRow(keys, columns, entry)
+	row := buildRow(keys, columns, entry, &config.EnrichmentConfig{})
 
 	if len(row) != 2 {
 		t.Fatalf("expected 2 fields (with fallback), got %d", len(row))
@@ -130,9 +130,160 @@ func TestBuildRowEmpty(t *testing.T) {
 	parser := gonx.NewParser(`$remote_addr`)
 	entry, _ := parser.ParseString(`192.168.1.1`)
 
-	row := buildRow(keys, columns, entry)
+	row := buildRow(keys, columns, entry, &config.EnrichmentConfig{})
 
 	if len(row) != 0 {
 		t.Errorf("expected 0 fields for empty columns, got %d", len(row))
+	}
+}
+
+func TestBuildRowEnrichment(t *testing.T) {
+	columns := map[string]string{
+		"Hostname": "_hostname",
+	}
+	keys := []string{"Hostname"}
+
+	parser := gonx.NewParser(`$remote_addr`)
+	entry, _ := parser.ParseString(`192.168.1.1`)
+
+	enrichments := &config.EnrichmentConfig{Hostname: "web-01"}
+	row := buildRow(keys, columns, entry, enrichments)
+
+	if len(row) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(row))
+	}
+	if row[0] != "web-01" {
+		t.Errorf("expected Hostname=web-01, got %v", row[0])
+	}
+}
+
+func TestBuildRowStatusClass(t *testing.T) {
+	columns := map[string]string{
+		"StatusClass": "_status_class",
+	}
+	keys := []string{"StatusClass"}
+
+	parser := gonx.NewParser(`$status`)
+	entry, _ := parser.ParseString(`200`)
+
+	row := buildRow(keys, columns, entry, &config.EnrichmentConfig{})
+
+	if len(row) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(row))
+	}
+	if row[0] != "2xx" {
+		t.Errorf("expected StatusClass=2xx, got %v", row[0])
+	}
+}
+
+func TestBuildRowStatusClassVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		expected string
+	}{
+		{"success", "200", "2xx"},
+		{"redirect", "301", "3xx"},
+		{"client error", "404", "4xx"},
+		{"server error", "500", "5xx"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			columns := map[string]string{"StatusClass": "_status_class"}
+			keys := []string{"StatusClass"}
+
+			parser := gonx.NewParser(`$status`)
+			entry, _ := parser.ParseString(tt.status)
+
+			row := buildRow(keys, columns, entry, &config.EnrichmentConfig{})
+
+			if len(row) != 1 {
+				t.Fatalf("expected 1 field, got %d", len(row))
+			}
+			if row[0] != tt.expected {
+				t.Errorf("expected StatusClass=%s, got %v", tt.expected, row[0])
+			}
+		})
+	}
+}
+
+func TestBuildRowExtraEnrichment(t *testing.T) {
+	columns := map[string]string{
+		"MyTag": "_extra.my_tag",
+	}
+	keys := []string{"MyTag"}
+
+	parser := gonx.NewParser(`$remote_addr`)
+	entry, _ := parser.ParseString(`192.168.1.1`)
+
+	enrichments := &config.EnrichmentConfig{
+		Extra: map[string]string{"my_tag": "us-east-1"},
+	}
+	row := buildRow(keys, columns, entry, enrichments)
+
+	if len(row) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(row))
+	}
+	if row[0] != "us-east-1" {
+		t.Errorf("expected MyTag=us-east-1, got %v", row[0])
+	}
+}
+
+func TestBuildRowExtraEnrichmentMissingKey(t *testing.T) {
+	columns := map[string]string{
+		"MyTag": "_extra.nonexistent",
+	}
+	keys := []string{"MyTag"}
+
+	parser := gonx.NewParser(`$remote_addr`)
+	entry, _ := parser.ParseString(`192.168.1.1`)
+
+	enrichments := &config.EnrichmentConfig{
+		Extra: map[string]string{"my_tag": "value"},
+	}
+	row := buildRow(keys, columns, entry, enrichments)
+
+	if len(row) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(row))
+	}
+	if row[0] != "" {
+		t.Errorf("expected empty string for missing extra key, got %v", row[0])
+	}
+}
+
+func TestBuildRowAllEnrichments(t *testing.T) {
+	columns := map[string]string{
+		"Hostname":    "_hostname",
+		"Environment": "_environment",
+		"Service":     "_service",
+		"RemoteAddr":  "remote_addr",
+	}
+	keys := []string{"Environment", "Hostname", "RemoteAddr", "Service"}
+
+	parser := gonx.NewParser(`$remote_addr`)
+	entry, _ := parser.ParseString(`10.0.0.1`)
+
+	enrichments := &config.EnrichmentConfig{
+		Hostname:    "web-02",
+		Environment: "production",
+		Service:     "api-gateway",
+	}
+	row := buildRow(keys, columns, entry, enrichments)
+
+	if len(row) != 4 {
+		t.Fatalf("expected 4 fields, got %d", len(row))
+	}
+
+	expected := map[int]any{
+		0: "production",
+		1: "web-02",
+		2: "10.0.0.1",
+		3: "api-gateway",
+	}
+	for i, want := range expected {
+		if row[i] != want {
+			t.Errorf("row[%d]: expected %v, got %v", i, want, row[i])
+		}
 	}
 }

--- a/clickhouse/integration_test.go
+++ b/clickhouse/integration_test.go
@@ -497,11 +497,11 @@ func TestIntegrationJSONLogsWithEnrichments(t *testing.T) {
 	// Verify all fields for the row with status 201.
 	var (
 		remoteAddr, httpReferer, httpUserAgent string
-		hostname, environment, service        string
-		statusClass                           string
-		status                                int32
-		bytesSent                             int64
-		requestTime                           float64
+		hostname, environment, service         string
+		statusClass                            string
+		status                                 int32
+		bytesSent                              int64
+		requestTime                            float64
 	)
 	if err := c.QueryRow(context.Background(),
 		`SELECT RemoteAddr, Status, BytesSent, RequestTime, HttpReferer, HttpUserAgent,

--- a/clickhouse/integration_test.go
+++ b/clickhouse/integration_test.go
@@ -265,3 +265,291 @@ func TestIntegrationConnectionReuse(t *testing.T) {
 		t.Error("expected Healthy to remain true after second Save")
 	}
 }
+
+// setupTestDBEnriched creates the test_nginx database and an enriched table
+// that includes extra columns for enrichment fields.
+func setupTestDBEnriched(t *testing.T) {
+	t.Helper()
+
+	c, err := clickhouse.Open(testConnOpts(""))
+	if err != nil {
+		t.Fatalf("connect to clickhouse: %v", err)
+	}
+	defer c.Close()
+
+	ctx := context.Background()
+
+	if err := c.Exec(ctx, "CREATE DATABASE IF NOT EXISTS test_nginx"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	if err := c.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS test_nginx.access_log_enriched (
+			RemoteAddr    String,
+			Status        Int32,
+			BytesSent     Int64,
+			RequestTime   Float64,
+			HttpReferer   String,
+			HttpUserAgent String,
+			Hostname      String,
+			Environment   String,
+			Service       String,
+			StatusClass   String
+		) ENGINE = MergeTree()
+		ORDER BY Hostname
+	`); err != nil {
+		t.Fatalf("create enriched table: %v", err)
+	}
+
+	if err := c.Exec(ctx, "TRUNCATE TABLE test_nginx.access_log_enriched"); err != nil {
+		t.Fatalf("truncate enriched table: %v", err)
+	}
+}
+
+// testEnrichedConfig returns a config that maps columns to the enriched table,
+// including enrichment fields prefixed with "_".
+func testEnrichedConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.ClickHouse.Host = envOrDefault("CLICKHOUSE_HOST", "localhost")
+	cfg.ClickHouse.Port = envOrDefault("CLICKHOUSE_PORT", "9000")
+	cfg.ClickHouse.DB = "test_nginx"
+	cfg.ClickHouse.Table = "access_log_enriched"
+	cfg.ClickHouse.Credentials.User = envOrDefault("CLICKHOUSE_USER", "default")
+	cfg.ClickHouse.Credentials.Password = envOrDefault("CLICKHOUSE_PASSWORD", "")
+	cfg.ClickHouse.Columns = map[string]string{
+		"RemoteAddr":    "remote_addr",
+		"Status":        "status",
+		"BytesSent":     "bytes_sent",
+		"RequestTime":   "request_time",
+		"HttpReferer":   "http_referer",
+		"HttpUserAgent": "http_user_agent",
+		"Hostname":      "_hostname",
+		"Environment":   "_environment",
+		"Service":       "_service",
+		"StatusClass":   "_status_class",
+	}
+	cfg.Settings.Enrichments.Hostname = "test-host"
+	cfg.Settings.Enrichments.Environment = "testing"
+	cfg.Settings.Enrichments.Service = "nginx-test"
+
+	return cfg
+}
+
+func TestIntegrationJSONLogs(t *testing.T) {
+	setupTestDB(t)
+	defer teardownTestDB(t)
+
+	cfg := testConfig()
+	client := NewClient(cfg)
+	defer client.Close()
+
+	logLines := []string{
+		`{"remote_addr":"192.168.1.1","remote_user":"frank","time_local":"10/Oct/2000:13:55:36 -0700","request":"GET /index.html HTTP/1.0","status":200,"bytes_sent":2326,"http_referer":"https://example.com","http_user_agent":"Mozilla/5.0"}`,
+		`{"remote_addr":"10.0.0.1","remote_user":"-","time_local":"10/Oct/2000:13:55:37 -0700","request":"POST /form HTTP/1.1","status":404,"bytes_sent":512,"http_referer":"-","http_user_agent":"curl/7.68.0"}`,
+	}
+
+	entries := nginx.ParseJSONLogs(logLines)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 parsed entries, got %d", len(entries))
+	}
+
+	if err := client.Save(entries); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c, err := clickhouse.Open(testConnOpts("test_nginx"))
+	if err != nil {
+		t.Fatalf("open connection: %v", err)
+	}
+	defer c.Close()
+
+	var count uint64
+	if err := c.QueryRow(context.Background(), "SELECT count() FROM test_nginx.access_log").Scan(&count); err != nil {
+		t.Fatalf("query count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 rows, got %d", count)
+	}
+
+	var remoteAddr string
+	var status int32
+	if err := c.QueryRow(context.Background(),
+		"SELECT RemoteAddr, Status FROM test_nginx.access_log WHERE Status = 200").Scan(&remoteAddr, &status); err != nil {
+		t.Fatalf("query row with status 200: %v", err)
+	}
+	if remoteAddr != "192.168.1.1" {
+		t.Errorf("expected RemoteAddr=192.168.1.1, got %s", remoteAddr)
+	}
+
+	if err := c.QueryRow(context.Background(),
+		"SELECT RemoteAddr, Status FROM test_nginx.access_log WHERE Status = 404").Scan(&remoteAddr, &status); err != nil {
+		t.Fatalf("query row with status 404: %v", err)
+	}
+	if remoteAddr != "10.0.0.1" {
+		t.Errorf("expected RemoteAddr=10.0.0.1, got %s", remoteAddr)
+	}
+}
+
+func TestIntegrationEnrichments(t *testing.T) {
+	setupTestDBEnriched(t)
+	defer teardownTestDB(t)
+
+	cfg := testEnrichedConfig()
+	client := NewClient(cfg)
+	defer client.Close()
+
+	logLines := []string{
+		`{"remote_addr":"192.168.1.1","status":200,"bytes_sent":2326,"request_time":0.123,"http_referer":"https://example.com","http_user_agent":"Mozilla/5.0"}`,
+		`{"remote_addr":"10.0.0.1","status":500,"bytes_sent":512,"request_time":1.456,"http_referer":"-","http_user_agent":"curl/7.68.0"}`,
+	}
+
+	entries := nginx.ParseJSONLogs(logLines)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 parsed entries, got %d", len(entries))
+	}
+
+	if err := client.Save(entries); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c, err := clickhouse.Open(testConnOpts("test_nginx"))
+	if err != nil {
+		t.Fatalf("open connection: %v", err)
+	}
+	defer c.Close()
+
+	var count uint64
+	if err := c.QueryRow(context.Background(), "SELECT count() FROM test_nginx.access_log_enriched").Scan(&count); err != nil {
+		t.Fatalf("query count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 rows, got %d", count)
+	}
+
+	// Verify enrichment values for the row with status 200.
+	var hostname, environment, service, statusClass string
+	if err := c.QueryRow(context.Background(),
+		"SELECT Hostname, Environment, Service, StatusClass FROM test_nginx.access_log_enriched WHERE Status = 200",
+	).Scan(&hostname, &environment, &service, &statusClass); err != nil {
+		t.Fatalf("query enrichment row (status 200): %v", err)
+	}
+	if hostname != "test-host" {
+		t.Errorf("expected Hostname=test-host, got %s", hostname)
+	}
+	if environment != "testing" {
+		t.Errorf("expected Environment=testing, got %s", environment)
+	}
+	if service != "nginx-test" {
+		t.Errorf("expected Service=nginx-test, got %s", service)
+	}
+	if statusClass != "2xx" {
+		t.Errorf("expected StatusClass=2xx, got %s", statusClass)
+	}
+
+	// Verify enrichment values for the row with status 500.
+	if err := c.QueryRow(context.Background(),
+		"SELECT Hostname, Environment, Service, StatusClass FROM test_nginx.access_log_enriched WHERE Status = 500",
+	).Scan(&hostname, &environment, &service, &statusClass); err != nil {
+		t.Fatalf("query enrichment row (status 500): %v", err)
+	}
+	if hostname != "test-host" {
+		t.Errorf("expected Hostname=test-host, got %s", hostname)
+	}
+	if environment != "testing" {
+		t.Errorf("expected Environment=testing, got %s", environment)
+	}
+	if service != "nginx-test" {
+		t.Errorf("expected Service=nginx-test, got %s", service)
+	}
+	if statusClass != "5xx" {
+		t.Errorf("expected StatusClass=5xx, got %s", statusClass)
+	}
+}
+
+func TestIntegrationJSONLogsWithEnrichments(t *testing.T) {
+	setupTestDBEnriched(t)
+	defer teardownTestDB(t)
+
+	cfg := testEnrichedConfig()
+	client := NewClient(cfg)
+	defer client.Close()
+
+	logLines := []string{
+		`{"remote_addr":"172.16.0.1","status":201,"bytes_sent":1024,"request_time":0.05,"http_referer":"https://app.example.com","http_user_agent":"Firefox/99.0"}`,
+		`{"remote_addr":"10.10.10.10","status":503,"bytes_sent":256,"request_time":5.0,"http_referer":"-","http_user_agent":"Python/3.11"}`,
+	}
+
+	entries := nginx.ParseJSONLogs(logLines)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 parsed entries, got %d", len(entries))
+	}
+
+	if err := client.Save(entries); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c, err := clickhouse.Open(testConnOpts("test_nginx"))
+	if err != nil {
+		t.Fatalf("open connection: %v", err)
+	}
+	defer c.Close()
+
+	// Verify all fields for the row with status 201.
+	var (
+		remoteAddr, httpReferer, httpUserAgent string
+		hostname, environment, service        string
+		statusClass                           string
+		status                                int32
+		bytesSent                             int64
+		requestTime                           float64
+	)
+	if err := c.QueryRow(context.Background(),
+		`SELECT RemoteAddr, Status, BytesSent, RequestTime, HttpReferer, HttpUserAgent,
+		        Hostname, Environment, Service, StatusClass
+		 FROM test_nginx.access_log_enriched WHERE Status = 201`,
+	).Scan(&remoteAddr, &status, &bytesSent, &requestTime, &httpReferer, &httpUserAgent,
+		&hostname, &environment, &service, &statusClass); err != nil {
+		t.Fatalf("query combined row (status 201): %v", err)
+	}
+
+	if remoteAddr != "172.16.0.1" {
+		t.Errorf("expected RemoteAddr=172.16.0.1, got %s", remoteAddr)
+	}
+	if status != 201 {
+		t.Errorf("expected Status=201, got %d", status)
+	}
+	if bytesSent != 1024 {
+		t.Errorf("expected BytesSent=1024, got %d", bytesSent)
+	}
+	if httpReferer != "https://app.example.com" {
+		t.Errorf("expected HttpReferer=https://app.example.com, got %s", httpReferer)
+	}
+	if httpUserAgent != "Firefox/99.0" {
+		t.Errorf("expected HttpUserAgent=Firefox/99.0, got %s", httpUserAgent)
+	}
+	if hostname != "test-host" {
+		t.Errorf("expected Hostname=test-host, got %s", hostname)
+	}
+	if environment != "testing" {
+		t.Errorf("expected Environment=testing, got %s", environment)
+	}
+	if service != "nginx-test" {
+		t.Errorf("expected Service=nginx-test, got %s", service)
+	}
+	if statusClass != "2xx" {
+		t.Errorf("expected StatusClass=2xx, got %s", statusClass)
+	}
+
+	// Verify enrichment fields for the row with status 503.
+	if err := c.QueryRow(context.Background(),
+		`SELECT RemoteAddr, StatusClass FROM test_nginx.access_log_enriched WHERE Status = 503`,
+	).Scan(&remoteAddr, &statusClass); err != nil {
+		t.Fatalf("query combined row (status 503): %v", err)
+	}
+	if remoteAddr != "10.10.10.10" {
+		t.Errorf("expected RemoteAddr=10.10.10.10, got %s", remoteAddr)
+	}
+	if statusClass != "5xx" {
+		t.Errorf("expected StatusClass=5xx, got %s", statusClass)
+	}
+}

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -12,6 +12,13 @@ settings:
     enabled: false            # enable circuit breaker
     threshold: 5              # consecutive failures before opening
     cooldown_secs: 60         # seconds before half-open probe
+  enrichments:
+    hostname: auto           # "auto" resolves to os.Hostname(), or a literal value
+    environment: production
+    service: my-api
+    # extra:                 # arbitrary key-value pairs
+    #   datacenter: us-east-1
+    #   cluster: web-prod
 # ClickHouse credentials
 clickhouse:
  db: metrics

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -37,8 +37,11 @@ clickhouse:
    BytesSent: bytes_sent
    HttpReferer: http_referer
    HttpUserAgent: http_user_agent
+   # Hostname: _hostname           # enrichment: from settings.enrichments.hostname
+   # StatusClass: _status_class    # enrichment: derived from status (2xx, 3xx, etc.)
 
 # NGINX
 nginx:
   log_type: main
+  # log_format_type: json    # "text" (default) or "json"
   log_format: $remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"

--- a/config/config.go
+++ b/config/config.go
@@ -74,8 +74,9 @@ type CredentialsConfig struct {
 
 // NginxConfig holds NGINX log format settings.
 type NginxConfig struct {
-	LogType   string `yaml:"log_type"`
-	LogFormat string `yaml:"log_format"`
+	LogType       string `yaml:"log_type"`
+	LogFormat     string `yaml:"log_format"`
+	LogFormatType string `yaml:"log_format_type"` // "text" (default) or "json"
 }
 
 var configPath string
@@ -182,6 +183,9 @@ func (c *Config) SetEnvVariables() {
 	}
 	if v := os.Getenv("NGINX_LOG_FORMAT"); v != "" {
 		c.Nginx.LogFormat = v
+	}
+	if v := os.Getenv("NGINX_LOG_FORMAT_TYPE"); v != "" {
+		c.Nginx.LogFormatType = v
 	}
 
 	if v := os.Getenv("BUFFER_TYPE"); v != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ type SettingsConfig struct {
 	Retry          RetryConfig          `yaml:"retry"`
 	Buffer         BufferConfig         `yaml:"buffer"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
+	Enrichments    EnrichmentConfig     `yaml:"enrichments"`
 }
 
 // BufferConfig holds buffering settings.
@@ -47,6 +48,16 @@ type BufferConfig struct {
 	Type         string `yaml:"type"`           // "memory" (default) or "disk"
 	DiskPath     string `yaml:"disk_path"`      // directory for disk buffer segments
 	MaxDiskBytes int64  `yaml:"max_disk_bytes"` // max disk usage in bytes
+}
+
+// EnrichmentConfig holds static fields added to every log entry.
+// Fields are resolved at startup and injected into each ClickHouse row
+// when a column maps to a special "_" prefixed source name (e.g. _hostname).
+type EnrichmentConfig struct {
+	Hostname    string            `yaml:"hostname"`    // "auto" = os.Hostname(), or literal value
+	Environment string            `yaml:"environment"` // e.g. "production", "staging"
+	Service     string            `yaml:"service"`     // service name tag
+	Extra       map[string]string `yaml:"extra"`       // arbitrary key-value pairs
 }
 
 // CircuitBreakerConfig holds circuit breaker settings.
@@ -221,5 +232,15 @@ func (c *Config) SetEnvVariables() {
 		} else {
 			c.Settings.CircuitBreaker.CooldownSecs = cooldown
 		}
+	}
+
+	if v := os.Getenv("ENRICHMENT_HOSTNAME"); v != "" {
+		c.Settings.Enrichments.Hostname = v
+	}
+	if v := os.Getenv("ENRICHMENT_ENVIRONMENT"); v != "" {
+		c.Settings.Enrichments.Environment = v
+	}
+	if v := os.Getenv("ENRICHMENT_SERVICE"); v != "" {
+		c.Settings.Enrichments.Service = v
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -360,6 +360,47 @@ func TestSetEnvVariablesCircuitBreaker(t *testing.T) {
 	}
 }
 
+func TestReadLogFormatType(t *testing.T) {
+	content := `
+settings:
+  interval: 5
+  log_path: /tmp/test.log
+clickhouse:
+  db: test
+  table: t
+  host: localhost
+  port: "9000"
+nginx:
+  log_type: main
+  log_format: ""
+  log_format_type: json
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath = tmpFile
+	cfg := Read()
+
+	if cfg.Nginx.LogFormatType != "json" {
+		t.Errorf("expected LogFormatType=json, got %s", cfg.Nginx.LogFormatType)
+	}
+}
+
+func TestSetEnvVariablesLogFormatType(t *testing.T) {
+	cfg := &Config{}
+
+	t.Setenv("NGINX_LOG_FORMAT_TYPE", "json")
+
+	cfg.SetEnvVariables()
+
+	if cfg.Nginx.LogFormatType != "json" {
+		t.Errorf("expected LogFormatType=json, got %s", cfg.Nginx.LogFormatType)
+	}
+}
+
 func TestSetEnvVariablesInvalidInterval(t *testing.T) {
 	cfg := &Config{}
 	cfg.Settings.Interval = 5

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -401,6 +401,73 @@ func TestSetEnvVariablesLogFormatType(t *testing.T) {
 	}
 }
 
+func TestReadEnrichmentConfig(t *testing.T) {
+	content := `
+settings:
+  interval: 5
+  log_path: /tmp/test.log
+  enrichments:
+    hostname: auto
+    environment: production
+    service: my-api
+    extra:
+      datacenter: us-east-1
+      cluster: web-prod
+clickhouse:
+  db: test
+  table: t
+  host: localhost
+  port: "9000"
+nginx:
+  log_type: main
+  log_format: "$remote_addr"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath = tmpFile
+	cfg := Read()
+
+	if cfg.Settings.Enrichments.Hostname != "auto" {
+		t.Errorf("expected Hostname=auto, got %s", cfg.Settings.Enrichments.Hostname)
+	}
+	if cfg.Settings.Enrichments.Environment != "production" {
+		t.Errorf("expected Environment=production, got %s", cfg.Settings.Enrichments.Environment)
+	}
+	if cfg.Settings.Enrichments.Service != "my-api" {
+		t.Errorf("expected Service=my-api, got %s", cfg.Settings.Enrichments.Service)
+	}
+	if cfg.Settings.Enrichments.Extra["datacenter"] != "us-east-1" {
+		t.Errorf("expected Extra[datacenter]=us-east-1, got %s", cfg.Settings.Enrichments.Extra["datacenter"])
+	}
+	if cfg.Settings.Enrichments.Extra["cluster"] != "web-prod" {
+		t.Errorf("expected Extra[cluster]=web-prod, got %s", cfg.Settings.Enrichments.Extra["cluster"])
+	}
+}
+
+func TestSetEnvVariablesEnrichments(t *testing.T) {
+	cfg := &Config{}
+
+	t.Setenv("ENRICHMENT_HOSTNAME", "override-host")
+	t.Setenv("ENRICHMENT_ENVIRONMENT", "staging")
+	t.Setenv("ENRICHMENT_SERVICE", "override-svc")
+
+	cfg.SetEnvVariables()
+
+	if cfg.Settings.Enrichments.Hostname != "override-host" {
+		t.Errorf("expected Hostname=override-host, got %s", cfg.Settings.Enrichments.Hostname)
+	}
+	if cfg.Settings.Enrichments.Environment != "staging" {
+		t.Errorf("expected Environment=staging, got %s", cfg.Settings.Enrichments.Environment)
+	}
+	if cfg.Settings.Enrichments.Service != "override-svc" {
+		t.Errorf("expected Service=override-svc, got %s", cfg.Settings.Enrichments.Service)
+	}
+}
+
 func TestSetEnvVariablesInvalidInterval(t *testing.T) {
 	cfg := &Config{}
 	cfg.Settings.Interval = 5

--- a/main.go
+++ b/main.go
@@ -84,9 +84,13 @@ func main() {
 		cfg.Settings.MaxBufferSize = defaultMaxBufferSize
 	}
 
-	parser, err := nginx.NewParser(cfg)
-	if err != nil {
-		logrus.Fatal("can't parse nginx log format: ", err)
+	var parser *nginx.Parser
+	if cfg.Nginx.LogFormatType != "json" {
+		var err error
+		parser, err = nginx.NewParser(cfg)
+		if err != nil {
+			logrus.Fatal("can't parse nginx log format: ", err)
+		}
 	}
 
 	client := clickhouse.NewClient(cfg)
@@ -111,7 +115,12 @@ func main() {
 		logrus.WithError(err).Error("buffer replay failed")
 	} else if len(recovered) > 0 {
 		logrus.WithField("lines", len(recovered)).Info("replaying recovered log lines")
-		entries := nginx.ParseLogs(parser, recovered)
+		var entries []nginx.LogEntry
+		if parser != nil {
+			entries = nginx.ParseLogs(parser, recovered)
+		} else {
+			entries = nginx.ParseJSONLogs(recovered)
+		}
 		if err := client.Save(entries); err != nil {
 			logrus.WithError(err).Error("failed to save recovered lines")
 		}
@@ -238,7 +247,12 @@ func flush(buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, c
 
 	logrus.WithField("entries", len(lines)).Info("preparing to save log entries")
 
-	entries := nginx.ParseLogs(parser, lines)
+	var entries []nginx.LogEntry
+	if parser != nil {
+		entries = nginx.ParseLogs(parser, lines)
+	} else {
+		entries = nginx.ParseJSONLogs(lines)
+	}
 
 	parseErrs := float64(len(lines) - len(entries))
 	if parseErrs > 0 {

--- a/main.go
+++ b/main.go
@@ -80,6 +80,16 @@ func main() {
 	cfg := configParser.Read()
 	cfg.SetEnvVariables()
 
+	// Resolve "auto" hostname enrichment.
+	if cfg.Settings.Enrichments.Hostname == "auto" {
+		h, err := os.Hostname()
+		if err != nil {
+			logrus.WithError(err).Warn("failed to resolve hostname for enrichment")
+		} else {
+			cfg.Settings.Enrichments.Hostname = h
+		}
+	}
+
 	if cfg.Settings.MaxBufferSize == 0 {
 		cfg.Settings.MaxBufferSize = defaultMaxBufferSize
 	}

--- a/nginx/json.go
+++ b/nginx/json.go
@@ -65,6 +65,10 @@ func anyToString(v any) string {
 	case nil:
 		return ""
 	default:
-		return fmt.Sprintf("%v", val)
+		b, err := json.Marshal(val)
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return string(b)
 	}
 }

--- a/nginx/json.go
+++ b/nginx/json.go
@@ -1,0 +1,70 @@
+// Package nginx provides NGINX access log parsing using configurable log formats.
+
+package nginx
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+// JSONEntry represents a parsed JSON log line.
+type JSONEntry struct {
+	fields map[string]string
+}
+
+// Field returns the value of the named field.
+func (e *JSONEntry) Field(name string) (string, error) {
+	v, ok := e.fields[name]
+	if !ok {
+		return "", fmt.Errorf("field %q not found", name)
+	}
+	return v, nil
+}
+
+// ParseJSONLogs parses JSON-formatted NGINX log lines into LogEntry values.
+// Each line must be a valid JSON object. Fields are flattened to string values.
+func ParseJSONLogs(logLines []string) []LogEntry {
+	if len(logLines) == 0 {
+		return nil
+	}
+
+	var entries []LogEntry
+	for _, line := range logLines {
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			logrus.WithError(err).WithField("line", line).Error("failed to parse JSON log line")
+			continue
+		}
+
+		fields := make(map[string]string, len(raw))
+		for k, v := range raw {
+			fields[k] = anyToString(v)
+		}
+		entries = append(entries, &JSONEntry{fields: fields})
+	}
+
+	return entries
+}
+
+// anyToString converts an arbitrary JSON value to its string representation.
+func anyToString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		// Use integer formatting when the value has no fractional part.
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10)
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(val)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/nginx/json_test.go
+++ b/nginx/json_test.go
@@ -1,0 +1,123 @@
+package nginx
+
+import (
+	"testing"
+)
+
+func TestParseJSONLogs(t *testing.T) {
+	lines := []string{
+		`{"remote_addr":"192.168.1.1","status":200,"request_time":0.123,"request":"GET /index.html HTTP/1.1"}`,
+		`{"remote_addr":"10.0.0.1","status":404,"request_time":0.456,"request":"POST /api HTTP/1.1"}`,
+	}
+
+	entries := ParseJSONLogs(lines)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	addr, err := entries[0].Field("remote_addr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if addr != "192.168.1.1" {
+		t.Errorf("expected remote_addr=192.168.1.1, got %s", addr)
+	}
+
+	addr, err = entries[1].Field("remote_addr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if addr != "10.0.0.1" {
+		t.Errorf("expected remote_addr=10.0.0.1, got %s", addr)
+	}
+
+	status, err := entries[0].Field("status")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "200" {
+		t.Errorf("expected status=200, got %s", status)
+	}
+}
+
+func TestParseJSONLogsInvalidLine(t *testing.T) {
+	lines := []string{
+		`{"remote_addr":"192.168.1.1","status":200}`,
+		`not valid json`,
+		`{"remote_addr":"10.0.0.1","status":404}`,
+	}
+
+	entries := ParseJSONLogs(lines)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (invalid line skipped), got %d", len(entries))
+	}
+
+	addr, err := entries[0].Field("remote_addr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if addr != "192.168.1.1" {
+		t.Errorf("expected remote_addr=192.168.1.1, got %s", addr)
+	}
+
+	addr, err = entries[1].Field("remote_addr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if addr != "10.0.0.1" {
+		t.Errorf("expected remote_addr=10.0.0.1, got %s", addr)
+	}
+}
+
+func TestParseJSONLogsEmpty(t *testing.T) {
+	entries := ParseJSONLogs([]string{})
+	if entries != nil {
+		t.Errorf("expected nil for empty input, got %v", entries)
+	}
+}
+
+func TestJSONEntryFieldNotFound(t *testing.T) {
+	entry := &JSONEntry{fields: map[string]string{"key": "value"}}
+
+	_, err := entry.Field("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent field")
+	}
+}
+
+func TestParseJSONLogsNumericValues(t *testing.T) {
+	lines := []string{
+		`{"int_val":42,"float_val":3.14,"bool_val":true,"null_val":null,"str_val":"hello"}`,
+	}
+
+	entries := ParseJSONLogs(lines)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	tests := []struct {
+		field    string
+		expected string
+	}{
+		{"int_val", "42"},
+		{"float_val", "3.14"},
+		{"bool_val", "true"},
+		{"null_val", ""},
+		{"str_val", "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			val, err := entries[0].Field(tt.field)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if val != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, val)
+			}
+		})
+	}
+}

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -67,9 +67,15 @@ func ParseField(key, value string) any {
 	}
 }
 
+// LogEntry represents a parsed log line with named fields.
+type LogEntry interface {
+	// Field returns the value of the named field.
+	Field(name string) (string, error)
+}
+
 // ParseLogs parses multiple raw NGINX log lines into structured entries using
 // the provided parser. Lines that fail to parse are logged and skipped.
-func ParseLogs(parser *Parser, logLines []string) []gonx.Entry {
+func ParseLogs(parser *Parser, logLines []string) []LogEntry {
 	if len(logLines) == 0 {
 		return nil
 	}
@@ -77,7 +83,7 @@ func ParseLogs(parser *Parser, logLines []string) []gonx.Entry {
 	logReader := strings.NewReader(strings.Join(logLines, "\n"))
 	reader := gonx.NewParserReader(logReader, parser)
 
-	var entries []gonx.Entry
+	var entries []LogEntry
 	for {
 		rec, err := reader.Read()
 		if errors.Is(err, io.EOF) {
@@ -87,7 +93,7 @@ func ParseLogs(parser *Parser, logLines []string) []gonx.Entry {
 			logrus.Errorf("failed to parse log line: %v", err)
 			continue
 		}
-		entries = append(entries, *rec)
+		entries = append(entries, rec)
 	}
 
 	return entries

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -51,6 +51,7 @@ func ParseField(key, value string) any {
 		val, err := strconv.Atoi(value)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"field": key, "value": value}).WithError(err).Error("cannot convert to int")
+			return value
 		}
 		return val
 
@@ -59,6 +60,7 @@ func ParseField(key, value string) any {
 		val, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"field": key, "value": value}).WithError(err).Error("cannot convert to float")
+			return value
 		}
 		return val
 


### PR DESCRIPTION
Add JSON log support and log enrichments

  - Introduce LogEntry interface to decouple parsing from gonx dependency
  - Add JSON access log parser (log_format_type: json) using encoding/json
    for NGINX escape=json format — no gonx parser needed in JSON mode
  - Add log enrichments via _ prefix in column mapping:
    _hostname (auto from os.Hostname), _environment, _service,
    _status_class (derived 2xx/3xx/etc), _extra.<key> for arbitrary tags
  - Validate status_class derivation against non-numeric values
  - Return original string on ParseField conversion errors instead of zero values
  - Handle nested JSON objects via json.Marshal in anyToString
  - Add integration tests for JSON logs, enrichments, and combined scenarios
  - Update config-sample.yml with log_format_type and enrichment examples
  - Update README with JSON log format docs, NGINX config example, enrichments section
  - 68 unit tests across 6 packages, all passing with -race