### PR TITLE
feat: add TLS support for ClickHouse connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Configuration is loaded from a YAML file (default: `config/config.yml`). All val
 | `CLICKHOUSE_TABLE` | ClickHouse table name |
 | `CLICKHOUSE_USER` | ClickHouse username |
 | `CLICKHOUSE_PASSWORD` | ClickHouse password |
+| `CLICKHOUSE_TLS` | Enable TLS (`true`/`false`) |
+| `CLICKHOUSE_TLS_SKIP_VERIFY` | Skip TLS certificate verification (`true`/`false`) |
+| `CLICKHOUSE_CA_CERT` | Path to custom CA certificate file |
 | `NGINX_LOG_TYPE` | NGINX log format name |
 | `NGINX_LOG_FORMAT` | NGINX log format string |
 | `NGINX_LOG_FORMAT_TYPE` | Log format type: `text` (default) or `json` |
@@ -130,7 +133,10 @@ clickhouse:
   db: metrics
   table: nginx
   host: localhost
-  port: 9000                     # native TCP port
+  port: 9000                     # native TCP port (9440 for TLS)
+  # tls: true                    # enable TLS
+  # tls_insecure_skip_verify: false
+  # ca_cert: /etc/ssl/clickhouse-ca.pem
   credentials:
     user: default
     password:
@@ -251,6 +257,21 @@ When a ClickHouse write fails, the client retries with exponential backoff and f
 - `backoff_max_secs` — maximum delay cap (default: 30s)
 
 The backoff doubles each attempt with random jitter to avoid thundering herd.
+
+### TLS / Secure Connections
+
+For ClickHouse Cloud or any TLS-secured cluster:
+
+```yaml
+clickhouse:
+  host: your-cluster.clickhouse.cloud
+  port: 9440
+  tls: true
+  # tls_insecure_skip_verify: true  # only for self-signed certs
+  # ca_cert: /etc/ssl/custom-ca.pem # custom CA certificate
+```
+
+The default ClickHouse secure native port is `9440`. Set `tls: true` to enable encrypted connections.
 
 ### Connection Recovery
 

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -4,8 +4,11 @@ package clickhouse
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -132,14 +135,34 @@ func (c *Client) connect() error {
 		return fmt.Errorf("invalid port %q: %w", c.cfg.ClickHouse.Port, err)
 	}
 
-	conn, err := clickhouse.Open(&clickhouse.Options{
+	opts := &clickhouse.Options{
 		Addr: []string{fmt.Sprintf("%s:%d", c.cfg.ClickHouse.Host, port)},
 		Auth: clickhouse.Auth{
 			Database: c.cfg.ClickHouse.DB,
 			Username: c.cfg.ClickHouse.Credentials.User,
 			Password: c.cfg.ClickHouse.Credentials.Password,
 		},
-	})
+	}
+
+	if c.cfg.ClickHouse.TLS {
+		tlsCfg := &tls.Config{
+			InsecureSkipVerify: c.cfg.ClickHouse.TLSInsecureSkipVerify,
+		}
+		if c.cfg.ClickHouse.CACert != "" {
+			caCert, err := os.ReadFile(c.cfg.ClickHouse.CACert)
+			if err != nil {
+				return fmt.Errorf("read CA cert %q: %w", c.cfg.ClickHouse.CACert, err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(caCert) {
+				return fmt.Errorf("invalid CA cert in %q", c.cfg.ClickHouse.CACert)
+			}
+			tlsCfg.RootCAs = pool
+		}
+		opts.TLS = tlsCfg
+	}
+
+	conn, err := clickhouse.Open(opts)
 	if err != nil {
 		return fmt.Errorf("open connection: %w", err)
 	}

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -25,6 +25,9 @@ clickhouse:
  table: nginx
  host: localhost
  port: 9000
+ # tls: false                          # enable TLS (use port 9440 for ClickHouse secure native)
+ # tls_insecure_skip_verify: false     # skip certificate verification (not recommended)
+ # ca_cert: /etc/ssl/clickhouse-ca.pem # path to custom CA certificate
  credentials:
   user: default
   password:

--- a/config/config.go
+++ b/config/config.go
@@ -69,12 +69,15 @@ type CircuitBreakerConfig struct {
 
 // ClickHouseConfig holds ClickHouse connection and schema settings.
 type ClickHouseConfig struct {
-	DB          string            `yaml:"db"`
-	Table       string            `yaml:"table"`
-	Host        string            `yaml:"host"`
-	Port        string            `yaml:"port"`
-	Columns     map[string]string `yaml:"columns"`
-	Credentials CredentialsConfig `yaml:"credentials"`
+	DB                    string            `yaml:"db"`
+	Table                 string            `yaml:"table"`
+	Host                  string            `yaml:"host"`
+	Port                  string            `yaml:"port"`
+	TLS                   bool              `yaml:"tls"`
+	TLSInsecureSkipVerify bool              `yaml:"tls_insecure_skip_verify"`
+	CACert                string            `yaml:"ca_cert"`
+	Columns               map[string]string `yaml:"columns"`
+	Credentials           CredentialsConfig `yaml:"credentials"`
 }
 
 // CredentialsConfig holds authentication credentials for ClickHouse.
@@ -187,6 +190,15 @@ func (c *Config) SetEnvVariables() {
 	}
 	if v := os.Getenv("CLICKHOUSE_PASSWORD"); v != "" {
 		c.ClickHouse.Credentials.Password = v
+	}
+	if v := os.Getenv("CLICKHOUSE_TLS"); v != "" {
+		c.ClickHouse.TLS = v == "true"
+	}
+	if v := os.Getenv("CLICKHOUSE_TLS_SKIP_VERIFY"); v != "" {
+		c.ClickHouse.TLSInsecureSkipVerify = v == "true"
+	}
+	if v := os.Getenv("CLICKHOUSE_CA_CERT"); v != "" {
+		c.ClickHouse.CACert = v
 	}
 
 	if v := os.Getenv("NGINX_LOG_TYPE"); v != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -360,6 +360,66 @@ func TestSetEnvVariablesCircuitBreaker(t *testing.T) {
 	}
 }
 
+func TestReadTLSConfig(t *testing.T) {
+	content := `
+settings:
+  interval: 5
+  log_path: /tmp/test.log
+clickhouse:
+  db: test
+  table: t
+  host: localhost
+  port: "9440"
+  tls: true
+  tls_insecure_skip_verify: false
+  ca_cert: /etc/ssl/ca.pem
+nginx:
+  log_type: main
+  log_format: "$remote_addr"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath = tmpFile
+	cfg := Read()
+
+	if !cfg.ClickHouse.TLS {
+		t.Error("expected TLS=true")
+	}
+	if cfg.ClickHouse.TLSInsecureSkipVerify {
+		t.Error("expected TLSInsecureSkipVerify=false")
+	}
+	if cfg.ClickHouse.CACert != "/etc/ssl/ca.pem" {
+		t.Errorf("expected CACert=/etc/ssl/ca.pem, got %s", cfg.ClickHouse.CACert)
+	}
+	if cfg.ClickHouse.Port != "9440" {
+		t.Errorf("expected Port=9440, got %s", cfg.ClickHouse.Port)
+	}
+}
+
+func TestSetEnvVariablesTLS(t *testing.T) {
+	cfg := &Config{}
+
+	t.Setenv("CLICKHOUSE_TLS", "true")
+	t.Setenv("CLICKHOUSE_TLS_SKIP_VERIFY", "true")
+	t.Setenv("CLICKHOUSE_CA_CERT", "/custom/ca.pem")
+
+	cfg.SetEnvVariables()
+
+	if !cfg.ClickHouse.TLS {
+		t.Error("expected TLS=true")
+	}
+	if !cfg.ClickHouse.TLSInsecureSkipVerify {
+		t.Error("expected TLSInsecureSkipVerify=true")
+	}
+	if cfg.ClickHouse.CACert != "/custom/ca.pem" {
+		t.Errorf("expected CACert=/custom/ca.pem, got %s", cfg.ClickHouse.CACert)
+	}
+}
+
 func TestReadLogFormatType(t *testing.T) {
 	content := `
 settings:


### PR DESCRIPTION
- Add tls, tls_insecure_skip_verify, ca_cert config fields
- Add CLICKHOUSE_TLS, CLICKHOUSE_TLS_SKIP_VERIFY, CLICKHOUSE_CA_CERT env vars
- Build crypto/tls config with optional custom CA certificate
- Default secure port is 9440 (ClickHouse native TLS)
- Update config-sample.yml and README with TLS docs