### PR TITLE
feat: add client certificate support for mutual TLS (mTLS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Configuration is loaded from a YAML file (default: `config/config.yml`). All val
 | `CLICKHOUSE_PASSWORD` | ClickHouse password |
 | `CLICKHOUSE_TLS` | Enable TLS (`true`/`false`) |
 | `CLICKHOUSE_TLS_SKIP_VERIFY` | Skip TLS certificate verification (`true`/`false`) |
-| `CLICKHOUSE_CA_CERT` | Path to custom CA certificate file |
+| `CLICKHOUSE_CA_CERT` | Path to CA certificate file |
+| `CLICKHOUSE_TLS_CERT_PATH` | Path to client TLS certificate (for mTLS) |
+| `CLICKHOUSE_TLS_KEY_PATH` | Path to client TLS private key (for mTLS) |
 | `NGINX_LOG_TYPE` | NGINX log format name |
 | `NGINX_LOG_FORMAT` | NGINX log format string |
 | `NGINX_LOG_FORMAT_TYPE` | Log format type: `text` (default) or `json` |
@@ -137,6 +139,8 @@ clickhouse:
   # tls: true                    # enable TLS
   # tls_insecure_skip_verify: false
   # ca_cert: /etc/ssl/clickhouse-ca.pem
+  # tls_cert_path: /etc/ssl/client.crt  # client cert for mTLS
+  # tls_key_path: /etc/ssl/client.key
   credentials:
     user: default
     password:
@@ -267,11 +271,13 @@ clickhouse:
   host: your-cluster.clickhouse.cloud
   port: 9440
   tls: true
-  # tls_insecure_skip_verify: true  # only for self-signed certs
-  # ca_cert: /etc/ssl/custom-ca.pem # custom CA certificate
+  # tls_insecure_skip_verify: true    # only for self-signed certs
+  # ca_cert: /etc/ssl/custom-ca.pem   # custom CA certificate
+  # tls_cert_path: /etc/ssl/client.crt  # client certificate (mTLS)
+  # tls_key_path: /etc/ssl/client.key   # client private key (mTLS)
 ```
 
-The default ClickHouse secure native port is `9440`. Set `tls: true` to enable encrypted connections.
+The default ClickHouse secure native port is `9440`. Set `tls: true` to enable encrypted connections. For mutual TLS (mTLS), provide both `tls_cert_path` and `tls_key_path`.
 
 ### Connection Recovery
 

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -159,6 +159,13 @@ func (c *Client) connect() error {
 			}
 			tlsCfg.RootCAs = pool
 		}
+		if c.cfg.ClickHouse.TLSCertPath != "" && c.cfg.ClickHouse.TLSKeyPath != "" {
+			cert, err := tls.LoadX509KeyPair(c.cfg.ClickHouse.TLSCertPath, c.cfg.ClickHouse.TLSKeyPath)
+			if err != nil {
+				return fmt.Errorf("load client certificate: %w", err)
+			}
+			tlsCfg.Certificates = []tls.Certificate{cert}
+		}
 		opts.TLS = tlsCfg
 	}
 

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -27,7 +27,9 @@ clickhouse:
  port: 9000
  # tls: false                          # enable TLS (use port 9440 for ClickHouse secure native)
  # tls_insecure_skip_verify: false     # skip certificate verification (not recommended)
- # ca_cert: /etc/ssl/clickhouse-ca.pem # path to custom CA certificate
+ # ca_cert: /etc/ssl/clickhouse-ca.pem # path to CA certificate
+ # tls_cert_path: /etc/ssl/client.crt  # path to client certificate (for mTLS)
+ # tls_key_path: /etc/ssl/client.key   # path to client private key (for mTLS)
  credentials:
   user: default
   password:

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,8 @@ type ClickHouseConfig struct {
 	TLS                   bool              `yaml:"tls"`
 	TLSInsecureSkipVerify bool              `yaml:"tls_insecure_skip_verify"`
 	CACert                string            `yaml:"ca_cert"`
+	TLSCertPath           string            `yaml:"tls_cert_path"`
+	TLSKeyPath            string            `yaml:"tls_key_path"`
 	Columns               map[string]string `yaml:"columns"`
 	Credentials           CredentialsConfig `yaml:"credentials"`
 }
@@ -199,6 +201,12 @@ func (c *Config) SetEnvVariables() {
 	}
 	if v := os.Getenv("CLICKHOUSE_CA_CERT"); v != "" {
 		c.ClickHouse.CACert = v
+	}
+	if v := os.Getenv("CLICKHOUSE_TLS_CERT_PATH"); v != "" {
+		c.ClickHouse.TLSCertPath = v
+	}
+	if v := os.Getenv("CLICKHOUSE_TLS_KEY_PATH"); v != "" {
+		c.ClickHouse.TLSKeyPath = v
 	}
 
 	if v := os.Getenv("NGINX_LOG_TYPE"); v != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -373,6 +373,8 @@ clickhouse:
   tls: true
   tls_insecure_skip_verify: false
   ca_cert: /etc/ssl/ca.pem
+  tls_cert_path: /etc/ssl/client.crt
+  tls_key_path: /etc/ssl/client.key
 nginx:
   log_type: main
   log_format: "$remote_addr"
@@ -398,6 +400,12 @@ nginx:
 	if cfg.ClickHouse.Port != "9440" {
 		t.Errorf("expected Port=9440, got %s", cfg.ClickHouse.Port)
 	}
+	if cfg.ClickHouse.TLSCertPath != "/etc/ssl/client.crt" {
+		t.Errorf("expected TLSCertPath=/etc/ssl/client.crt, got %s", cfg.ClickHouse.TLSCertPath)
+	}
+	if cfg.ClickHouse.TLSKeyPath != "/etc/ssl/client.key" {
+		t.Errorf("expected TLSKeyPath=/etc/ssl/client.key, got %s", cfg.ClickHouse.TLSKeyPath)
+	}
 }
 
 func TestSetEnvVariablesTLS(t *testing.T) {
@@ -406,6 +414,8 @@ func TestSetEnvVariablesTLS(t *testing.T) {
 	t.Setenv("CLICKHOUSE_TLS", "true")
 	t.Setenv("CLICKHOUSE_TLS_SKIP_VERIFY", "true")
 	t.Setenv("CLICKHOUSE_CA_CERT", "/custom/ca.pem")
+	t.Setenv("CLICKHOUSE_TLS_CERT_PATH", "/custom/client.crt")
+	t.Setenv("CLICKHOUSE_TLS_KEY_PATH", "/custom/client.key")
 
 	cfg.SetEnvVariables()
 
@@ -417,6 +427,12 @@ func TestSetEnvVariablesTLS(t *testing.T) {
 	}
 	if cfg.ClickHouse.CACert != "/custom/ca.pem" {
 		t.Errorf("expected CACert=/custom/ca.pem, got %s", cfg.ClickHouse.CACert)
+	}
+	if cfg.ClickHouse.TLSCertPath != "/custom/client.crt" {
+		t.Errorf("expected TLSCertPath=/custom/client.crt, got %s", cfg.ClickHouse.TLSCertPath)
+	}
+	if cfg.ClickHouse.TLSKeyPath != "/custom/client.key" {
+		t.Errorf("expected TLSKeyPath=/custom/client.key, got %s", cfg.ClickHouse.TLSKeyPath)
 	}
 }
 


### PR DESCRIPTION
- Add tls_cert_path and tls_key_path config fields for client certs
- Add CLICKHOUSE_TLS_CERT_PATH and CLICKHOUSE_TLS_KEY_PATH env vars
- Load X509 key pair when both paths are configured
- Update tests, config-sample.yml, and README