### PR TITLE
feat: add expression-based log filtering and sampling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,11 +83,11 @@ CI will reject PRs that fail any of these checks.
 ## Testing
 
 ```bash
-go test ./... -v -race              # 92 unit tests across 8 packages
+go test ./... -v -race              # 145 unit tests across 8 packages
 go test ./clickhouse/ -v -tags integration  # Integration tests (requires ClickHouse)
 ```
 
-Packages with tests: main (5), retry (7), buffer (10), circuitbreaker (5), clickhouse (15 unit + 12 integration), config (23), filter (14), nginx (15).
+Packages with tests: main (5), retry (7), buffer (10), circuitbreaker (5), clickhouse (15 unit + 12 integration), config (33), filter (23), nginx (39).
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ main.go                    → Entry point: tail, buffer, flush loop, graceful s
 config/config.go           → YAML config + env var overrides (structured types)
 nginx/nginx.go             → Parses NGINX log lines using gonx (configurable log format)
 nginx/json.go              → Parses NGINX JSON access logs (log_format escape=json) and applies enrichments
+filter/filter.go           → Expression-based filtering and sampling (expr-lang/expr)
 clickhouse/clickhouse.go   → Client struct: connection mgmt, retry-wrapped Save, health check, async inserts
 retry/retry.go             → Exponential backoff with full jitter
 buffer/buffer.go           → Buffer interface + MemoryBuffer
@@ -18,7 +19,7 @@ buffer/disk.go             → DiskBuffer: segment-file append, rotation, crash 
 circuitbreaker/circuitbreaker.go → Circuit breaker (closed/open/half-open states)
 ```
 
-Flow: startup replay (disk buffer) → tail log → buffer lines (memory or disk) → periodic flush (or buffer-full trigger) → parse → retry-wrapped batch insert → graceful shutdown on SIGTERM.
+Flow: startup replay (disk buffer) → tail log → buffer lines (memory or disk) → periodic flush (or buffer-full trigger) → parse → filter/sample → retry-wrapped batch insert → graceful shutdown on SIGTERM.
 
 ## Build & Run
 
@@ -46,6 +47,7 @@ go run main.go            # Run locally (reads config/config.yml by default)
 - `satyrius/gonx` — NGINX log format parsing
 - `sirupsen/logrus` — structured JSON logging
 - `prometheus/client_golang` — Prometheus metrics
+- `expr-lang/expr` — Expression evaluation for log filtering
 - `gopkg.in/yaml.v2` — YAML config parsing
 - No external deps for retry, buffer, or circuit breaker (pure Go stdlib)
 
@@ -81,11 +83,11 @@ CI will reject PRs that fail any of these checks.
 ## Testing
 
 ```bash
-go test ./... -v -race              # 78 unit tests across 7 packages
+go test ./... -v -race              # 92 unit tests across 8 packages
 go test ./clickhouse/ -v -tags integration  # Integration tests (requires ClickHouse)
 ```
 
-Packages with tests: main (5), retry (7), buffer (10), circuitbreaker (5), clickhouse (15 unit + 12 integration), config (21), nginx (15).
+Packages with tests: main (5), retry (7), buffer (10), circuitbreaker (5), clickhouse (15 unit + 12 integration), config (23), filter (14), nginx (15).
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ settings:
 Each rule has:
 - **`expr`** — boolean expression evaluated against log fields
 - **`action`** — `drop` (remove matching entries) or `keep` (retain only matching entries)
-- **`sample_rate`** (optional, 0-1) — fraction of matches affected by the action. `0.9` on a drop rule means drop 90% of matches, keep 10%.
+- **`sample_rate`** (optional, 0-1) — fraction of matches affected by the action. On a `drop` rule, `0.9` means drop 90% of matches (keep 10%). On a `keep` rule, `0.1` means retain 10% of matches (drop the rest along with non-matching entries).
 
 Rules are applied sequentially: drop rules remove entries first, then keep rules narrow the remainder.
 
@@ -573,6 +573,7 @@ Output:
 ```
 ✓ Config loaded
 ✓ Log format: JSON
+✓ Filters: 3 rules compiled
 ✓ Log file: /var/log/nginx/access.log
 ✓ ClickHouse connection: OK (localhost:9000)
 ✓ Database: OK ("metrics" exists)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Simple NGINX access log parser and transporter to ClickHouse database. Uses the 
 - **Graceful shutdown** — flushes buffer on SIGTERM/SIGINT or EOF
 - `/healthz` endpoint for Kubernetes liveness/readiness probes
 - Prometheus metrics: buffer size, flush latency, parse errors, circuit breaker state
+- **Expression-based filtering and sampling** — drop health checks, keep only 5xx, sample 10% of 2xx, etc. via [expr-lang](https://expr-lang.org/)
 - Structured JSON logging
 - Configuration via YAML file or environment variables
 - Minimal Docker image (scratch-based)
@@ -143,6 +144,7 @@ Configuration is loaded from a YAML file (default: `config/config.yml`). All val
 | `ENRICHMENT_HOSTNAME` | Hostname to add to logs (`auto` for os.Hostname) |
 | `ENRICHMENT_ENVIRONMENT` | Environment tag (e.g., `production`) |
 | `ENRICHMENT_SERVICE` | Service name tag |
+| `FILTER_RULES` | Filter rules in compact format: `expr:action[:sample_rate]` separated by `;` (see [Filtering & Sampling](#filtering--sampling)) |
 | `ENRICHMENT_<key>` | Any other `ENRICHMENT_` var is added to the extra map (suffix lowercased, e.g. `ENRICHMENT_POD_NAMESPACE=default` sets `extra["pod_namespace"]`) |
 
 ### Full Config Example
@@ -288,6 +290,7 @@ Available at `http://localhost:2112/metrics`:
 | `nginx_clickhouse_lines_not_processed_total` | Total log lines that failed to save |
 | `nginx_clickhouse_lines_read_total` | Total lines read from the log file |
 | `nginx_clickhouse_parse_errors_total` | Total lines that failed to parse |
+| `nginx_clickhouse_lines_filtered_total` | Total entries dropped by filter rules |
 | `nginx_clickhouse_buffer_size` | Current number of lines in the buffer |
 | `nginx_clickhouse_clickhouse_up` | Whether ClickHouse is reachable (1/0) |
 | `nginx_clickhouse_flush_duration_seconds` | Time spent per flush (histogram) |
@@ -419,6 +422,81 @@ Map enrichment fields to ClickHouse columns using the `_` prefix in the column m
 | `_service` | Service name tag |
 | `_status_class` | HTTP status class derived from the `status` field (e.g., `2xx`, `4xx`, `5xx`) |
 | `_extra.<key>` | Arbitrary key-value pairs from the `enrichments.extra` map |
+
+## Filtering & Sampling
+
+Filter and sample parsed log entries before they are saved to ClickHouse. Rules use the [expr](https://expr-lang.org/) expression language and are evaluated post-parse against structured log fields.
+
+### Configuration
+
+```yaml
+settings:
+  filters:
+    - expr: 'request contains "/health"'
+      action: drop                         # drop health check noise
+    - expr: 'status >= 200 && status < 300'
+      action: drop
+      sample_rate: 0.9                     # drop 90% of 2xx (keep 10%)
+    - expr: 'request_time == 0'
+      action: drop                         # drop cached responses
+    - expr: 'status >= 500'
+      action: keep                         # keep only 5xx
+```
+
+Each rule has:
+- **`expr`** — boolean expression evaluated against log fields
+- **`action`** — `drop` (remove matching entries) or `keep` (retain only matching entries)
+- **`sample_rate`** (optional, 0-1) — fraction of matches affected by the action. `0.9` on a drop rule means drop 90% of matches, keep 10%.
+
+Rules are applied sequentially: drop rules remove entries first, then keep rules narrow the remainder.
+
+### Available Fields
+
+Expressions can reference any NGINX log field from your column mapping. Numeric fields are automatically converted for comparisons:
+
+| Type | Fields |
+|---|---|
+| **Integer** | `status`, `bytes_sent`, `body_bytes_sent`, `request_length`, `connection`, `connections_active`, `connections_waiting` |
+| **Float** | `request_time`, `upstream_response_time`, `upstream_connect_time`, `upstream_header_time`, `msec` |
+| **String** | `remote_addr`, `remote_user`, `request`, `http_referer`, `http_user_agent`, and any other field |
+
+### Expression Examples
+
+```yaml
+# Numeric comparisons (no type casting needed)
+- expr: 'status >= 500'
+- expr: 'request_time > 1.0'
+- expr: 'bytes_sent == 0'
+
+# String operations
+- expr: 'request contains "/api/v2"'
+- expr: 'http_user_agent contains "bot"'
+- expr: 'request matches "^GET /health"'      # regex
+
+# Combined conditions
+- expr: 'status == 200 && request contains "/health"'
+- expr: 'status >= 400 || request_time > 5'
+```
+
+### Environment Variable
+
+For simple rules, use the `FILTER_RULES` env var with compact `expr:action[:sample_rate]` format, separated by `;`:
+
+```sh
+FILTER_RULES="status >= 500:keep;request_time == 0:drop"
+```
+
+> **Note:** `FILTER_RULES` uses `:` as a delimiter. Expressions containing `:` (e.g., URLs) should use YAML config instead.
+
+### Validation
+
+Filter expressions are compiled and validated at startup. Invalid expressions cause the service to exit with an error. Use `-check` to validate filters without starting:
+
+```
+✓ Filters: 3 rules compiled
+```
+
+Monitor `nginx_clickhouse_lines_filtered_total` to track how many entries are being dropped.
 
 ### Health Check
 

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -33,6 +33,8 @@ settings:
   #   - expr: 'status >= 500'
   #     action: keep                       # keep only 5xx (drop everything else)
   # Env var: FILTER_RULES="status >= 500:keep;request contains /health:drop"
+  # Note: FILTER_RULES uses ":" as delimiter — expressions containing ":" (e.g. URLs)
+  # should use YAML config instead.
 # ClickHouse credentials
 clickhouse:
  db: metrics

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -22,6 +22,17 @@ settings:
     # Any ENRICHMENT_ env var not matching a known field (HOSTNAME, ENVIRONMENT, SERVICE)
     # is added to extra automatically:
     #   ENRICHMENT_POD_NAMESPACE=default → extra["pod_namespace"] = "default"
+  # filters:                              # filter/sample parsed entries before saving
+  #   - expr: 'request contains "/health"' # drop health check noise
+  #     action: drop
+  #   - expr: 'status >= 200 && status < 300'
+  #     action: drop                       # drop all 2xx
+  #     sample_rate: 0.9                   # actually, drop 90% of 2xx (keep 10%)
+  #   - expr: 'request_time == 0'
+  #     action: drop                       # drop cached responses with zero latency
+  #   - expr: 'status >= 500'
+  #     action: keep                       # keep only 5xx (drop everything else)
+  # Env var: FILTER_RULES="status >= 500:keep;request contains /health:drop"
 # ClickHouse credentials
 clickhouse:
  db: metrics

--- a/config/config.go
+++ b/config/config.go
@@ -277,6 +277,35 @@ func (c *Config) SetEnvVariables() {
 		c.Settings.Enrichments.Service = v
 	}
 
+	if v := os.Getenv("FILTER_RULES"); v != "" {
+		var rules []FilterRule
+		for _, part := range strings.Split(v, ";") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			tokens := strings.SplitN(part, ":", 3)
+			if len(tokens) < 2 {
+				logrus.Errorf("invalid FILTER_RULES entry %q: expected expr:action[:sample_rate]", part)
+				continue
+			}
+			rule := FilterRule{
+				Expr:   strings.TrimSpace(tokens[0]),
+				Action: strings.TrimSpace(tokens[1]),
+			}
+			if len(tokens) == 3 {
+				rate, err := strconv.ParseFloat(strings.TrimSpace(tokens[2]), 64)
+				if err != nil {
+					logrus.Errorf("invalid sample_rate in FILTER_RULES entry %q: %v", part, err)
+					continue
+				}
+				rule.SampleRate = rate
+			}
+			rules = append(rules, rule)
+		}
+		c.Settings.Filters = rules
+	}
+
 	// Any ENRICHMENT_ env var not matching a known field goes into the extra map.
 	known := map[string]bool{"ENRICHMENT_HOSTNAME": true, "ENRICHMENT_ENVIRONMENT": true, "ENRICHMENT_SERVICE": true}
 	if c.Settings.Enrichments.Extra == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type SettingsConfig struct {
 	Buffer         BufferConfig         `yaml:"buffer"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
 	Enrichments    EnrichmentConfig     `yaml:"enrichments"`
+	Filters        []FilterRule         `yaml:"filters"`
 }
 
 // BufferConfig holds buffering settings.
@@ -59,6 +60,13 @@ type EnrichmentConfig struct {
 	Environment string            `yaml:"environment"` // e.g. "production", "staging"
 	Service     string            `yaml:"service"`     // service name tag
 	Extra       map[string]string `yaml:"extra"`       // arbitrary key-value pairs
+}
+
+// FilterRule defines a single filter/sampling rule evaluated against parsed log entries.
+type FilterRule struct {
+	Expr       string  `yaml:"expr"`        // expr-lang expression, must return bool
+	Action     string  `yaml:"action"`      // "drop" (discard matches) or "keep" (retain only matches)
+	SampleRate float64 `yaml:"sample_rate"` // 0 = no sampling; 0.1 = keep 10% of matches
 }
 
 // CircuitBreakerConfig holds circuit breaker settings.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestRead(t *testing.T) {
@@ -686,6 +688,61 @@ func TestSetEnvVariablesEnrichmentExtraEmptyValue(t *testing.T) {
 	}
 	if val != "" {
 		t.Errorf("expected empty string, got %s", val)
+	}
+}
+
+func TestFiltersConfig(t *testing.T) {
+	yamlData := `
+settings:
+  interval: 5
+  log_path: test.log
+  filters:
+    - expr: 'status >= 200 && status < 300'
+      action: drop
+    - expr: 'status == 200'
+      action: keep
+      sample_rate: 0.1
+clickhouse:
+  db: metrics
+  table: nginx
+  host: localhost
+  port: "9000"
+  credentials:
+    user: default
+    password: ""
+  columns:
+    Status: status
+nginx:
+  log_type: main
+  log_format: '$remote_addr'
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(cfg.Settings.Filters) != 2 {
+		t.Fatalf("expected 2 filters, got %d", len(cfg.Settings.Filters))
+	}
+
+	if cfg.Settings.Filters[0].Expr != "status >= 200 && status < 300" {
+		t.Errorf("unexpected expr: %s", cfg.Settings.Filters[0].Expr)
+	}
+	if cfg.Settings.Filters[0].Action != "drop" {
+		t.Errorf("unexpected action: %s", cfg.Settings.Filters[0].Action)
+	}
+	if cfg.Settings.Filters[0].SampleRate != 0 {
+		t.Errorf("unexpected sample_rate: %f", cfg.Settings.Filters[0].SampleRate)
+	}
+
+	if cfg.Settings.Filters[1].Expr != "status == 200" {
+		t.Errorf("unexpected expr: %s", cfg.Settings.Filters[1].Expr)
+	}
+	if cfg.Settings.Filters[1].Action != "keep" {
+		t.Errorf("unexpected action: %s", cfg.Settings.Filters[1].Action)
+	}
+	if cfg.Settings.Filters[1].SampleRate != 0.1 {
+		t.Errorf("unexpected sample_rate: %f", cfg.Settings.Filters[1].SampleRate)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -746,6 +746,49 @@ nginx:
 	}
 }
 
+func TestFiltersEnvVar(t *testing.T) {
+	yamlData := `
+settings:
+  interval: 5
+  log_path: test.log
+clickhouse:
+  db: metrics
+  table: nginx
+  host: localhost
+  port: "9000"
+  credentials:
+    user: default
+    password: ""
+  columns:
+    Status: status
+nginx:
+  log_type: main
+  log_format: '$remote_addr'
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	t.Setenv("FILTER_RULES", `status >= 500:keep;request_time == 0:drop:0.5`)
+	cfg.SetEnvVariables()
+
+	if len(cfg.Settings.Filters) != 2 {
+		t.Fatalf("expected 2 filters, got %d", len(cfg.Settings.Filters))
+	}
+
+	if cfg.Settings.Filters[0].Expr != "status >= 500" {
+		t.Errorf("unexpected expr: %s", cfg.Settings.Filters[0].Expr)
+	}
+	if cfg.Settings.Filters[0].Action != "keep" {
+		t.Errorf("unexpected action: %s", cfg.Settings.Filters[0].Action)
+	}
+
+	if cfg.Settings.Filters[1].SampleRate != 0.5 {
+		t.Errorf("unexpected sample_rate: %f", cfg.Settings.Filters[1].SampleRate)
+	}
+}
+
 func TestSetEnvVariablesEnrichmentExtraSkipsKnownFields(t *testing.T) {
 	cfg := &Config{}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,25 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const minimalYAML = `
+settings:
+  interval: 5
+  log_path: test.log
+clickhouse:
+  db: metrics
+  table: nginx
+  host: localhost
+  port: "9000"
+  credentials:
+    user: default
+    password: ""
+  columns:
+    Status: status
+nginx:
+  log_type: main
+  log_format: '$remote_addr'
+`
+
 func TestRead(t *testing.T) {
 	content := `
 settings:
@@ -816,5 +835,86 @@ func TestSetEnvVariablesEnrichmentExtraSkipsKnownFields(t *testing.T) {
 	// Known fields should NOT be in extra
 	if _, ok := cfg.Settings.Enrichments.Extra["hostname"]; ok {
 		t.Error("expected hostname to NOT be in Extra map")
+	}
+}
+
+func TestFiltersEnvVarEdgeCases(t *testing.T) {
+	t.Run("empty string", func(t *testing.T) {
+		var cfg Config
+		if err := yaml.Unmarshal([]byte(minimalYAML), &cfg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		t.Setenv("FILTER_RULES", "")
+		cfg.SetEnvVariables()
+		if len(cfg.Settings.Filters) != 0 {
+			t.Errorf("expected 0 filters, got %d", len(cfg.Settings.Filters))
+		}
+	})
+
+	t.Run("trailing semicolons", func(t *testing.T) {
+		var cfg Config
+		if err := yaml.Unmarshal([]byte(minimalYAML), &cfg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		t.Setenv("FILTER_RULES", "status >= 500:keep;")
+		cfg.SetEnvVariables()
+		if len(cfg.Settings.Filters) != 1 {
+			t.Errorf("expected 1 filter, got %d", len(cfg.Settings.Filters))
+		}
+	})
+
+	t.Run("single token no colon", func(t *testing.T) {
+		var cfg Config
+		if err := yaml.Unmarshal([]byte(minimalYAML), &cfg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		t.Setenv("FILTER_RULES", "invalid-no-colon")
+		cfg.SetEnvVariables()
+		if len(cfg.Settings.Filters) != 0 {
+			t.Errorf("expected 0 filters (invalid entry skipped), got %d", len(cfg.Settings.Filters))
+		}
+	})
+}
+
+func TestFiltersEnvVarReplacesYAML(t *testing.T) {
+	yamlWithFilters := `
+settings:
+  interval: 5
+  log_path: test.log
+  filters:
+    - expr: 'status == 200'
+      action: drop
+    - expr: 'status == 300'
+      action: drop
+clickhouse:
+  db: metrics
+  table: nginx
+  host: localhost
+  port: "9000"
+  credentials:
+    user: default
+    password: ""
+  columns:
+    Status: status
+nginx:
+  log_type: main
+  log_format: '$remote_addr'
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlWithFilters), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(cfg.Settings.Filters) != 2 {
+		t.Fatalf("expected 2 YAML filters, got %d", len(cfg.Settings.Filters))
+	}
+
+	t.Setenv("FILTER_RULES", "status >= 500:keep")
+	cfg.SetEnvVariables()
+
+	if len(cfg.Settings.Filters) != 1 {
+		t.Fatalf("expected 1 filter (env replaces YAML), got %d", len(cfg.Settings.Filters))
+	}
+	if cfg.Settings.Filters[0].Expr != "status >= 500" {
+		t.Errorf("unexpected expr: %s", cfg.Settings.Filters[0].Expr)
 	}
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,0 +1,207 @@
+// Package filter provides expression-based filtering and sampling for parsed
+// NGINX log entries using github.com/expr-lang/expr.
+package filter
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+	"github.com/sirupsen/logrus"
+
+	"github.com/mintance/nginx-clickhouse/config"
+)
+
+// LogEntry is the interface for parsed log entries (matches nginx.LogEntry).
+type LogEntry interface {
+	Field(name string) (string, error)
+}
+
+// compiledRule holds a pre-compiled expression and its associated action.
+type compiledRule struct {
+	program    *vm.Program
+	action     string  // "drop" or "keep"
+	sampleRate float64 // 0 = disabled (process all matches), 0-1 = fraction
+	raw        string  // original expression for logging
+}
+
+// Chain is an ordered list of compiled filter rules.
+type Chain struct {
+	rules  []compiledRule
+	fields []string // field names to extract from entries
+}
+
+// numericFields are NGINX log fields that should be converted to numeric types
+// for expression evaluation (so users can write status >= 500 instead of
+// int(status) >= 500).
+var numericFields = map[string]string{
+	"bytes_sent":             "int",
+	"body_bytes_sent":        "int",
+	"connections_waiting":    "int",
+	"connections_active":     "int",
+	"status":                 "int",
+	"connection":             "int",
+	"request_length":         "int",
+	"request_time":           "float",
+	"upstream_connect_time":  "float",
+	"upstream_header_time":   "float",
+	"upstream_response_time": "float",
+	"msec":                   "float",
+}
+
+// NewChain compiles the filter rules and returns a Chain ready for use.
+// The fields parameter lists all field names that will be available in
+// expressions (used to build the type environment for the compiler).
+func NewChain(rules []config.FilterRule, fields []string) (*Chain, error) {
+	if len(rules) == 0 {
+		return &Chain{}, nil
+	}
+
+	// Build a sample environment for expr type-checking.
+	env := buildEnvSample(fields)
+
+	compiled := make([]compiledRule, 0, len(rules))
+	for _, r := range rules {
+		if r.Action != "drop" && r.Action != "keep" {
+			return nil, fmt.Errorf("invalid filter action %q (must be \"drop\" or \"keep\")", r.Action)
+		}
+
+		program, err := expr.Compile(r.Expr, expr.Env(env), expr.AsBool())
+		if err != nil {
+			return nil, fmt.Errorf("compile filter %q: %w", r.Expr, err)
+		}
+
+		compiled = append(compiled, compiledRule{
+			program:    program,
+			action:     r.Action,
+			sampleRate: r.SampleRate,
+			raw:        r.Expr,
+		})
+	}
+
+	return &Chain{rules: compiled, fields: fields}, nil
+}
+
+// Apply evaluates all rules against entries and returns the filtered result.
+// Rules are applied in order. For "drop" rules, matching entries are removed.
+// For "keep" rules, only matching entries are retained.
+// When a rule has a sample_rate, only that fraction of matching entries are
+// affected by the action.
+func (c *Chain) Apply(entries []LogEntry) []LogEntry {
+	if len(c.rules) == 0 || len(entries) == 0 {
+		return entries
+	}
+
+	result := entries
+	for _, rule := range c.rules {
+		result = applyRule(rule, result, c.fields)
+	}
+	return result
+}
+
+// applyRule filters entries through a single compiled rule.
+func applyRule(rule compiledRule, entries []LogEntry, fields []string) []LogEntry {
+	kept := make([]LogEntry, 0, len(entries))
+	for _, entry := range entries {
+		env := buildEnv(entry, fields)
+		output, err := expr.Run(rule.program, env)
+		if err != nil {
+			logrus.WithError(err).WithField("expr", rule.raw).Warn("filter expression error, keeping entry")
+			kept = append(kept, entry)
+			continue
+		}
+
+		matched, ok := output.(bool)
+		if !ok {
+			kept = append(kept, entry)
+			continue
+		}
+
+		if !matched {
+			// Rule doesn't match this entry — pass through unchanged.
+			if rule.action == "keep" {
+				// "keep" rule: non-matching entries are dropped.
+				continue
+			}
+			kept = append(kept, entry)
+			continue
+		}
+
+		// Rule matches. Apply sampling if configured.
+		if rule.sampleRate > 0 && rule.sampleRate < 1 && rand.Float64() >= rule.sampleRate {
+			// Sampling says skip this match — invert the action.
+			if rule.action == "drop" {
+				kept = append(kept, entry) // not sampled for drop → keep
+			}
+			// "keep" with sampling: not sampled → drop
+			continue
+		}
+
+		// Matched and sampled (or no sampling). Apply action.
+		if rule.action == "keep" {
+			kept = append(kept, entry)
+		}
+		// "drop" action: entry is not added to kept.
+	}
+	return kept
+}
+
+// buildEnvSample creates a sample environment map with zero values of the
+// correct types for expr compile-time type-checking.
+func buildEnvSample(fields []string) map[string]any {
+	env := make(map[string]any, len(fields))
+	for _, f := range fields {
+		switch numericFields[f] {
+		case "int":
+			env[f] = 0
+		case "float":
+			env[f] = 0.0
+		default:
+			env[f] = ""
+		}
+	}
+	return env
+}
+
+// buildEnv extracts field values from a LogEntry into a map suitable for
+// expr.Run. Numeric fields are converted to their appropriate types.
+func buildEnv(entry LogEntry, fields []string) map[string]any {
+	env := make(map[string]any, len(fields))
+	for _, f := range fields {
+		val, err := entry.Field(f)
+		if err != nil {
+			// Field not present — use zero value matching the type.
+			switch numericFields[f] {
+			case "int":
+				env[f] = 0
+			case "float":
+				env[f] = 0.0
+			default:
+				env[f] = ""
+			}
+			continue
+		}
+
+		switch numericFields[f] {
+		case "int":
+			n, err := strconv.Atoi(val)
+			if err != nil {
+				env[f] = 0
+			} else {
+				env[f] = n
+			}
+		case "float":
+			n, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				env[f] = 0.0
+			} else {
+				env[f] = n
+			}
+		default:
+			env[f] = val
+		}
+	}
+	return env
+}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -63,6 +63,9 @@ func NewChain(rules []config.FilterRule, fields []string) (*Chain, error) {
 		if r.Action != "drop" && r.Action != "keep" {
 			return nil, fmt.Errorf("invalid filter action %q (must be \"drop\" or \"keep\")", r.Action)
 		}
+		if r.SampleRate < 0 || r.SampleRate > 1 {
+			return nil, fmt.Errorf("invalid sample_rate %g for filter %q (must be 0-1)", r.SampleRate, r.Expr)
+		}
 
 		program, err := expr.Compile(r.Expr, expr.Env(env), expr.AsBool())
 		if err != nil {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -12,12 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/mintance/nginx-clickhouse/config"
+	"github.com/mintance/nginx-clickhouse/nginx"
 )
-
-// LogEntry is the interface for parsed log entries (matches nginx.LogEntry).
-type LogEntry interface {
-	Field(name string) (string, error)
-}
 
 // compiledRule holds a pre-compiled expression and its associated action.
 type compiledRule struct {
@@ -89,7 +85,7 @@ func NewChain(rules []config.FilterRule, fields []string) (*Chain, error) {
 // For "keep" rules, only matching entries are retained.
 // When a rule has a sample_rate, only that fraction of matching entries are
 // affected by the action.
-func (c *Chain) Apply(entries []LogEntry) []LogEntry {
+func (c *Chain) Apply(entries []nginx.LogEntry) []nginx.LogEntry {
 	if len(c.rules) == 0 || len(entries) == 0 {
 		return entries
 	}
@@ -102,8 +98,8 @@ func (c *Chain) Apply(entries []LogEntry) []LogEntry {
 }
 
 // applyRule filters entries through a single compiled rule.
-func applyRule(rule compiledRule, entries []LogEntry, fields []string) []LogEntry {
-	kept := make([]LogEntry, 0, len(entries))
+func applyRule(rule compiledRule, entries []nginx.LogEntry, fields []string) []nginx.LogEntry {
+	kept := make([]nginx.LogEntry, 0, len(entries))
 	for _, entry := range entries {
 		env := buildEnv(entry, fields)
 		output, err := expr.Run(rule.program, env)
@@ -167,7 +163,7 @@ func buildEnvSample(fields []string) map[string]any {
 
 // buildEnv extracts field values from a LogEntry into a map suitable for
 // expr.Run. Numeric fields are converted to their appropriate types.
-func buildEnv(entry LogEntry, fields []string) map[string]any {
+func buildEnv(entry nginx.LogEntry, fields []string) map[string]any {
 	env := make(map[string]any, len(fields))
 	for _, f := range fields {
 		val, err := entry.Field(f)

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -158,12 +158,13 @@ func TestSampleRateOneKeepsAll(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []nginx.LogEntry{
-		&testEntry{fields: map[string]string{"status": "200"}},
+	entries := make([]nginx.LogEntry, 100)
+	for i := range entries {
+		entries[i] = &testEntry{fields: map[string]string{"status": "200"}}
 	}
 	result := chain.Apply(entries)
-	if len(result) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(result))
+	if len(result) != 100 {
+		t.Errorf("expected 100 entries, got %d", len(result))
 	}
 }
 
@@ -261,5 +262,179 @@ func TestSampleRateOutOfBounds(t *testing.T) {
 				t.Fatalf("expected error for sample_rate %g", tt.rate)
 			}
 		})
+	}
+}
+
+func TestDropWithFractionalSampling(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "drop", SampleRate: 0.5},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	const n = 10000
+	entries := make([]nginx.LogEntry, n)
+	for i := range entries {
+		entries[i] = &testEntry{fields: map[string]string{"status": "200"}}
+	}
+	result := chain.Apply(entries)
+	// With rate 0.5, roughly 50% should be dropped, 50% kept.
+	// Allow wide margin for randomness.
+	kept := len(result)
+	if kept < 3000 || kept > 7000 {
+		t.Errorf("expected ~5000 kept, got %d (outside 3000-7000 range)", kept)
+	}
+}
+
+func TestKeepWithFractionalSampling(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "keep", SampleRate: 0.5},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	const n = 10000
+	entries := make([]nginx.LogEntry, n)
+	for i := range entries {
+		entries[i] = &testEntry{fields: map[string]string{"status": "200"}}
+	}
+	result := chain.Apply(entries)
+	kept := len(result)
+	if kept < 3000 || kept > 7000 {
+		t.Errorf("expected ~5000 kept, got %d (outside 3000-7000 range)", kept)
+	}
+}
+
+func TestMissingFieldUsesZeroValue(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "request_time > 1", Action: "keep"},
+	}
+	// Compile with request_time as a known field
+	chain, err := NewChain(rules, []string{"request_time"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	// Entry has NO request_time field — should default to 0.0, which fails > 1
+	entries := []nginx.LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 0 {
+		t.Errorf("expected 0 entries (missing field defaults to 0), got %d", len(result))
+	}
+}
+
+func TestNonNumericValueInNumericField(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 0", Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	// "abc" can't be parsed as int, falls back to 0, matches status == 0
+	entries := []nginx.LogEntry{
+		&testEntry{fields: map[string]string{"status": "abc"}},
+		&testEntry{fields: map[string]string{"status": "200"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	v, _ := result[0].Field("status")
+	if v != "200" {
+		t.Errorf("expected status 200, got %s", v)
+	}
+}
+
+func TestApplyEmptyEntries(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	result := chain.Apply(nil)
+	if len(result) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(result))
+	}
+}
+
+func TestMultipleDropRules(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: `request contains "/health"`, Action: "drop"},
+		{Expr: "status == 304", Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"status", "request"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []nginx.LogEntry{
+		&testEntry{fields: map[string]string{"status": "200", "request": "/healthz"}},
+		&testEntry{fields: map[string]string{"status": "304", "request": "/api"}},
+		&testEntry{fields: map[string]string{"status": "200", "request": "/api"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	v, _ := result[0].Field("request")
+	if v != "/api" {
+		t.Errorf("expected /api, got %s", v)
+	}
+}
+
+func TestRuleOrderMatters(t *testing.T) {
+	// keep-then-drop: keep 5xx first, then drop 503 specifically
+	rules := []config.FilterRule{
+		{Expr: "status >= 500", Action: "keep"},
+		{Expr: "status == 503", Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []nginx.LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+		&testEntry{fields: map[string]string{"status": "500"}},
+		&testEntry{fields: map[string]string{"status": "503"}},
+	}
+	result := chain.Apply(entries)
+	// keep >= 500 leaves [500, 503], then drop 503 leaves [500]
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	v, _ := result[0].Field("status")
+	if v != "500" {
+		t.Errorf("expected status 500, got %s", v)
+	}
+}
+
+func TestUnknownFieldAsString(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: `gzip_ratio == "5.00"`, Action: "keep"},
+	}
+	chain, err := NewChain(rules, []string{"gzip_ratio"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []nginx.LogEntry{
+		&testEntry{fields: map[string]string{"gzip_ratio": "5.00"}},
+		&testEntry{fields: map[string]string{"gzip_ratio": "1.20"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
 	}
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -242,3 +242,24 @@ func TestRegexMatch(t *testing.T) {
 		t.Fatalf("expected 1 entry, got %d", len(result))
 	}
 }
+
+func TestSampleRateOutOfBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		rate float64
+	}{
+		{"negative", -0.5},
+		{"over_one", 2.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := []config.FilterRule{
+				{Expr: "status == 200", Action: "drop", SampleRate: tt.rate},
+			}
+			_, err := NewChain(rules, []string{"status"})
+			if err == nil {
+				t.Fatalf("expected error for sample_rate %g", tt.rate)
+			}
+		})
+	}
+}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mintance/nginx-clickhouse/config"
+	"github.com/mintance/nginx-clickhouse/nginx"
 )
 
 // testEntry is a minimal LogEntry for testing.
@@ -49,7 +50,7 @@ func TestDropRule(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"status": "200"}},
 		&testEntry{fields: map[string]string{"status": "500"}},
 		&testEntry{fields: map[string]string{"status": "201"}},
@@ -74,7 +75,7 @@ func TestKeepRule(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"status": "200"}},
 		&testEntry{fields: map[string]string{"status": "503"}},
 	}
@@ -99,7 +100,7 @@ func TestMultipleRules(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"status": "200", "request": "/healthz"}},
 		&testEntry{fields: map[string]string{"status": "500", "request": "/api"}},
 		&testEntry{fields: map[string]string{"status": "200", "request": "/api"}},
@@ -121,7 +122,7 @@ func TestEmptyChain(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"status": "200"}},
 	}
 	result := chain.Apply(entries)
@@ -139,7 +140,7 @@ func TestSampleRateZeroKeepsAll(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"status": "200"}},
 	}
 	result := chain.Apply(entries)
@@ -157,7 +158,7 @@ func TestSampleRateOneKeepsAll(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"status": "200"}},
 	}
 	result := chain.Apply(entries)
@@ -175,7 +176,7 @@ func TestDropWithSamplingDropsFraction(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := make([]LogEntry, 100)
+	entries := make([]nginx.LogEntry, 100)
 	for i := range entries {
 		entries[i] = &testEntry{fields: map[string]string{"status": "200"}}
 	}
@@ -194,7 +195,7 @@ func TestFloatFieldComparison(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"request_time": "0.000"}},
 		&testEntry{fields: map[string]string{"request_time": "1.234"}},
 	}
@@ -213,7 +214,7 @@ func TestStringContains(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"request": "GET /healthz HTTP/1.1"}},
 		&testEntry{fields: map[string]string{"request": "GET /api/users HTTP/1.1"}},
 	}
@@ -232,7 +233,7 @@ func TestRegexMatch(t *testing.T) {
 		t.Fatalf("NewChain: %v", err)
 	}
 
-	entries := []LogEntry{
+	entries := []nginx.LogEntry{
 		&testEntry{fields: map[string]string{"request": "GET /healthz HTTP/1.1"}},
 		&testEntry{fields: map[string]string{"request": "POST /api HTTP/1.1"}},
 	}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1,0 +1,243 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mintance/nginx-clickhouse/config"
+)
+
+// testEntry is a minimal LogEntry for testing.
+type testEntry struct {
+	fields map[string]string
+}
+
+func (e *testEntry) Field(name string) (string, error) {
+	v, ok := e.fields[name]
+	if !ok {
+		return "", fmt.Errorf("field %q not found", name)
+	}
+	return v, nil
+}
+
+func TestNewChainInvalidExpr(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "???invalid", Action: "drop"},
+	}
+	_, err := NewChain(rules, []string{"status"})
+	if err == nil {
+		t.Fatal("expected error for invalid expression")
+	}
+}
+
+func TestNewChainInvalidAction(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "invalid"},
+	}
+	_, err := NewChain(rules, []string{"status"})
+	if err == nil {
+		t.Fatal("expected error for invalid action")
+	}
+}
+
+func TestDropRule(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status >= 200 && status < 300", Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+		&testEntry{fields: map[string]string{"status": "500"}},
+		&testEntry{fields: map[string]string{"status": "201"}},
+	}
+
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	v, _ := result[0].Field("status")
+	if v != "500" {
+		t.Errorf("expected status 500, got %s", v)
+	}
+}
+
+func TestKeepRule(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status >= 500", Action: "keep"},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+		&testEntry{fields: map[string]string{"status": "503"}},
+	}
+
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	v, _ := result[0].Field("status")
+	if v != "503" {
+		t.Errorf("expected status 503, got %s", v)
+	}
+}
+
+func TestMultipleRules(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: `request == "/healthz"`, Action: "drop"},
+		{Expr: "status >= 500", Action: "keep"},
+	}
+	chain, err := NewChain(rules, []string{"status", "request"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"status": "200", "request": "/healthz"}},
+		&testEntry{fields: map[string]string{"status": "500", "request": "/api"}},
+		&testEntry{fields: map[string]string{"status": "200", "request": "/api"}},
+	}
+
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	v, _ := result[0].Field("status")
+	if v != "500" {
+		t.Errorf("expected status 500, got %s", v)
+	}
+}
+
+func TestEmptyChain(t *testing.T) {
+	chain, err := NewChain(nil, nil)
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry (passthrough), got %d", len(result))
+	}
+}
+
+func TestSampleRateZeroKeepsAll(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "keep", SampleRate: 0},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+}
+
+func TestSampleRateOneKeepsAll(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "keep", SampleRate: 1.0},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"status": "200"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+}
+
+func TestDropWithSamplingDropsFraction(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "status == 200", Action: "drop", SampleRate: 1.0},
+	}
+	chain, err := NewChain(rules, []string{"status"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := make([]LogEntry, 100)
+	for i := range entries {
+		entries[i] = &testEntry{fields: map[string]string{"status": "200"}}
+	}
+	result := chain.Apply(entries)
+	if len(result) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(result))
+	}
+}
+
+func TestFloatFieldComparison(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: "request_time == 0", Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"request_time"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"request_time": "0.000"}},
+		&testEntry{fields: map[string]string{"request_time": "1.234"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+}
+
+func TestStringContains(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: `request contains "/health"`, Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"request"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"request": "GET /healthz HTTP/1.1"}},
+		&testEntry{fields: map[string]string{"request": "GET /api/users HTTP/1.1"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+}
+
+func TestRegexMatch(t *testing.T) {
+	rules := []config.FilterRule{
+		{Expr: `request matches "^GET /health"`, Action: "drop"},
+	}
+	chain, err := NewChain(rules, []string{"request"})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+
+	entries := []LogEntry{
+		&testEntry{fields: map[string]string{"request": "GET /healthz HTTP/1.1"}},
+		&testEntry{fields: map[string]string{"request": "POST /api HTTP/1.1"}},
+	}
+	result := chain.Apply(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
+	github.com/expr-lang/expr v1.17.8
 	github.com/papertrail/go-tail v0.0.0-20221103124010-5087eb6a0a07
 	github.com/prometheus/client_golang v1.23.2
 	github.com/satyrius/gonx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mintance/nginx-clickhouse/circuitbreaker"
 	"github.com/mintance/nginx-clickhouse/clickhouse"
 	configParser "github.com/mintance/nginx-clickhouse/config"
+	"github.com/mintance/nginx-clickhouse/filter"
 	"github.com/mintance/nginx-clickhouse/nginx"
 )
 
@@ -88,6 +89,11 @@ var (
 		Name: "nginx_clickhouse_circuit_breaker_rejections_total",
 		Help: "Total flushes rejected by circuit breaker",
 	})
+
+	linesFiltered = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "nginx_clickhouse_lines_filtered_total",
+		Help: "Total log entries dropped by filter rules",
+	})
 )
 
 func main() {
@@ -117,6 +123,25 @@ func main() {
 		if err != nil {
 			logrus.Fatal("can't parse nginx log format: ", err)
 		}
+	}
+
+	// Compile filter rules.
+	var filterChain *filter.Chain
+	if len(cfg.Settings.Filters) > 0 {
+		// Collect field names from column mappings (excluding enrichment fields).
+		var fields []string
+		for _, source := range cfg.ClickHouse.Columns {
+			if !strings.HasPrefix(source, "_") {
+				fields = append(fields, source)
+			}
+		}
+
+		var err error
+		filterChain, err = filter.NewChain(cfg.Settings.Filters, fields)
+		if err != nil {
+			logrus.Fatal("invalid filter rules: ", err)
+		}
+		logrus.WithField("rules", len(cfg.Settings.Filters)).Info("filter rules compiled")
 	}
 
 	if cfg.ClickHouse.UseServerSideBatching {
@@ -158,6 +183,9 @@ func main() {
 			entries = nginx.ParseLogs(parser, recovered)
 		} else {
 			entries = nginx.ParseJSONLogs(recovered)
+		}
+		if filterChain != nil {
+			entries = filterChain.Apply(entries)
 		}
 		if err := client.Save(entries); err != nil {
 			logrus.WithError(err).Error("failed to save recovered lines")
@@ -202,13 +230,13 @@ func main() {
 	// Priority: -stdin > -once > tail (continuous).
 	lines := openLineSource(cfg)
 
-	go flushLoop(cfg, buf, parser, client, cb)
+	go flushLoop(cfg, buf, parser, client, cb, filterChain)
 
 	// Guard against concurrent shutdown from signal + EOF.
 	var shutdownOnce sync.Once
 	doShutdown := func() {
 		shutdownOnce.Do(func() {
-			flush(buf, parser, client, cb)
+			flush(buf, parser, client, cb, filterChain)
 			client.Close()
 			if closer, ok := buf.(io.Closer); ok {
 				closer.Close()
@@ -237,7 +265,7 @@ func main() {
 		}
 		bufferSize.Set(float64(buf.Len()))
 		if buf.Len() >= cfg.Settings.MaxBufferSize {
-			flush(buf, parser, client, cb)
+			flush(buf, parser, client, cb, filterChain)
 		}
 	}
 
@@ -314,16 +342,16 @@ func scanLines(r io.Reader) <-chan string {
 }
 
 // flushLoop periodically flushes buffered log lines to ClickHouse.
-func flushLoop(cfg *configParser.Config, buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, cb *circuitbreaker.CircuitBreaker) {
+func flushLoop(cfg *configParser.Config, buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, cb *circuitbreaker.CircuitBreaker, fc *filter.Chain) {
 	interval := time.Duration(cfg.Settings.Interval) * time.Second
 	for {
 		time.Sleep(interval)
-		flush(buf, parser, client, cb)
+		flush(buf, parser, client, cb, fc)
 	}
 }
 
 // flush drains the log buffer and saves entries to ClickHouse.
-func flush(buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, cb *circuitbreaker.CircuitBreaker) {
+func flush(buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, cb *circuitbreaker.CircuitBreaker, fc *filter.Chain) {
 	// Circuit breaker check BEFORE draining the buffer to avoid data loss.
 	if cb != nil && !cb.Allow() {
 		logrus.Warn("circuit breaker open, skipping flush")
@@ -356,7 +384,25 @@ func flush(buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, c
 	if parseErrs > 0 {
 		parseErrors.Add(parseErrs)
 	}
+
+	if fc != nil {
+		before := len(entries)
+		entries = fc.Apply(entries)
+		if dropped := before - len(entries); dropped > 0 {
+			linesFiltered.Add(float64(dropped))
+			logrus.WithFields(logrus.Fields{
+				"before": before,
+				"after":  len(entries),
+			}).Debug("filter applied")
+		}
+	}
+
 	batchSize.Observe(float64(len(entries)))
+
+	if len(entries) == 0 {
+		logrus.Debug("all entries filtered, skipping save")
+		return
+	}
 
 	if err := client.Save(entries); err != nil {
 		logrus.WithError(err).Error("can't save logs")

--- a/main.go
+++ b/main.go
@@ -463,6 +463,25 @@ func runCheck(cfg *configParser.Config, parser *nginx.Parser, client *clickhouse
 		allOK = false
 	}
 
+	// Filters
+	if len(cfg.Settings.Filters) > 0 {
+		var fields []string
+		for _, source := range cfg.ClickHouse.Columns {
+			if !strings.HasPrefix(source, "_") {
+				fields = append(fields, source)
+			}
+		}
+		_, err := filter.NewChain(cfg.Settings.Filters, fields)
+		if err != nil {
+			fmt.Printf("✗ Filters: %v\n", err)
+			allOK = false
+		} else {
+			fmt.Printf("✓ Filters: %d rules compiled\n", len(cfg.Settings.Filters))
+		}
+	} else {
+		fmt.Println("· Filters: none configured")
+	}
+
 	// Log file
 	if _, err := os.Stat(cfg.Settings.LogPath); err != nil {
 		fmt.Printf("✗ Log file: %s (%v)\n", cfg.Settings.LogPath, err)

--- a/main.go
+++ b/main.go
@@ -406,7 +406,7 @@ func flush(buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, c
 
 	if err := client.Save(entries); err != nil {
 		logrus.WithError(err).Error("can't save logs")
-		linesNotProcessed.Add(float64(len(lines)))
+		linesNotProcessed.Add(float64(len(entries)))
 		clickhouseUp.Set(0)
 		if cb != nil {
 			cb.RecordFailure()
@@ -421,8 +421,8 @@ func flush(buf buffer.Buffer, parser *nginx.Parser, client *clickhouse.Client, c
 		}
 		bufferSize.Set(float64(buf.Len()))
 	} else {
-		logrus.WithField("entries", len(lines)).Info("saved log entries")
-		linesProcessed.Add(float64(len(lines)))
+		logrus.WithField("entries", len(entries)).Info("saved log entries")
+		linesProcessed.Add(float64(len(entries)))
 		clickhouseUp.Set(1)
 		if cb != nil {
 			cb.RecordSuccess()


### PR DESCRIPTION
## Summary

  - Add configurable filter/sampling layer using [expr-lang](https://expr-lang.org/) expressions, evaluated post-parse against structured log fields
  - Support `drop` (remove matches) and `keep` (retain only matches) actions with optional `sample_rate` (0-1) per rule
  - Auto-coerce numeric NGINX fields (`status`, `request_time`, etc.) so users write `status >= 500` not `int(status) >= 500`
  - Rules configurable via YAML (`settings.filters`) or env var (`FILTER_RULES`)
  - Add `nginx_clickhouse_lines_filtered_total` Prometheus metric
  - Validate filter expressions at startup and via `-check` flag

## Example

  ```yaml
  settings:
    filters:
      - expr: 'request contains "/health"'
        action: drop
      - expr: 'status >= 200 && status < 300'
        action: drop
        sample_rate: 0.9   # drop 90% of 2xx, keep 10%
      - expr: 'request_time == 0'
        action: drop
      - expr: 'status >= 500'
        action: keep
```
## Motivation

Users frequently need to reduce log volume before it reaches ClickHouse — dropping health checks, sampling high-volume 2xx traffic, filtering cached responses with zero latency. Previously this required an extra hop through Vector/Fluent Bit. This feature handles it natively with a small expression DSL.

## Changes
  - New package: filter/ — expr compilation, drop/keep/sampling logic, numeric field coercion
  - Modified: config/config.go — FilterRule struct, FILTER_RULES env var parsing
  - Modified: main.go — filter chain init, wired into flush(), flushLoop(), replay, --check
  - Modified: config-sample.yml — documented filter examples
  - Modified: README.md — new Filtering & Sampling section, updated metrics table, env vars, --check output
  - Modified: CLAUDE.md — architecture, deps, test counts

## Test plan
  - 21 filter tests: drop, keep, sampling (deterministic + statistical), missing fields, non-numeric fallback, empty entries, multiple rules, rule ordering, regex, contains, unknown fields, invalid
  expr/action/sample_rate
  - 5 config tests: YAML parsing, env var parsing, edge cases (empty, trailing ;, no colon), env replaces YAML
  - Full suite: 145 tests across 8 packages, all pass with -race
  - gofmt, go vet clean