### PR TITLE
feat: improve OpenSSF Scorecard — security policy, SAST, fuzz tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,21 @@ jobs:
       - name: Lint
         run: make lint
 
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
   unit-test:
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +47,24 @@ jobs:
       - name: Build
         run: make build
 
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Fuzz nginx parsers
+        run: |
+          go test ./nginx/ -fuzz=FuzzParseField -fuzztime=30s
+          go test ./nginx/ -fuzz=FuzzParseLogs -fuzztime=30s
+          go test ./nginx/ -fuzz=FuzzParseJSONLogs -fuzztime=30s
+
+      - name: Fuzz filter
+        run: go test ./filter/ -fuzz=FuzzChainApply -fuzztime=30s
+
   validate-k8s-manifests:
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +72,7 @@ jobs:
 
       - name: Install kubeconform
         run: |
-          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | \
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | \
             sudo tar -xz -C /usr/local/bin kubeconform
 
       - name: Validate Kubernetes manifests
@@ -49,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server:latest
+        image: clickhouse/clickhouse-server:24.12
         ports:
           - 9000:9000
           - 8123:8123

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install kubeconform
         run: |
-          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | \
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | \
             sudo tar -xz -C /usr/local/bin kubeconform
 
       - name: Validate Kubernetes manifests
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server:24.12
+        image: clickhouse/clickhouse-server:latest
         ports:
           - 9000:9000
           - 8123:8123

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,12 +13,11 @@ responsibly.
 
 **Please do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please send an email to **security@motiv8.team** with:
+Instead, use [GitHub's private vulnerability reporting](https://github.com/mintance/nginx-clickhouse/security/advisories/new):
 
-- A description of the vulnerability
-- Steps to reproduce the issue
-- Any relevant logs or screenshots
-- Your suggested fix (if any)
+1. Go to the **Security** tab of this repository
+2. Click **Report a vulnerability**
+3. Fill in the details (description, steps to reproduce, impact)
 
 We will acknowledge receipt within 48 hours and aim to provide a fix or
 mitigation plan within 7 days.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ responsibly.
 
 **Please do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please send an email to **security@mintance.com** with:
+Instead, please send an email to **security@motiv8.team** with:
 
 - A description of the vulnerability
 - Steps to reproduce the issue

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please send an email to **security@mintance.com** with:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any relevant logs or screenshots
+- Your suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or
+mitigation plan within 7 days.
+
+## Disclosure Policy
+
+- We will work with you to understand and resolve the issue before any public
+  disclosure.
+- We will credit reporters in the release notes (unless you prefer to remain
+  anonymous).

--- a/filter/fuzz_test.go
+++ b/filter/fuzz_test.go
@@ -1,0 +1,56 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mintance/nginx-clickhouse/config"
+	"github.com/mintance/nginx-clickhouse/nginx"
+)
+
+// stubEntry is a minimal LogEntry for fuzz testing.
+type stubEntry struct {
+	fields map[string]string
+}
+
+func (e *stubEntry) Field(name string) (string, error) {
+	v, ok := e.fields[name]
+	if !ok {
+		return "", fmt.Errorf("field %q not found", name)
+	}
+	return v, nil
+}
+
+func FuzzChainApply(f *testing.F) {
+	f.Add(`status >= 500`, "drop", "200", "/index.html")
+	f.Add(`request contains "/health"`, "drop", "200", "/healthz")
+	f.Add(`status == 404`, "keep", "404", "/missing")
+	f.Add(`status < 300`, "keep", "301", "/redirect")
+	f.Add(`request == "GET / HTTP/1.1"`, "drop", "200", "GET / HTTP/1.1")
+
+	fields := []string{"status", "request"}
+
+	f.Fuzz(func(t *testing.T, expression, action, status, request string) {
+		if action != "drop" && action != "keep" {
+			t.Skip()
+		}
+
+		rules := []config.FilterRule{
+			{Expr: expression, Action: action},
+		}
+
+		chain, err := NewChain(rules, fields)
+		if err != nil {
+			// Invalid expressions are expected — not a bug.
+			t.Skip()
+		}
+
+		entry := &stubEntry{fields: map[string]string{
+			"status":  status,
+			"request": request,
+		}}
+
+		// Apply must not panic on any input.
+		_ = chain.Apply([]nginx.LogEntry{entry})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mintance/nginx-clickhouse
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0

--- a/nginx/fuzz_test.go
+++ b/nginx/fuzz_test.go
@@ -37,6 +37,7 @@ func FuzzParseField(f *testing.F) {
 func FuzzParseLogs(f *testing.F) {
 	f.Add(`93.180.71.3 - - [17/May/2015:08:05:32 +0000] "GET /downloads/product_1 HTTP/1.1" 304 0 "-" "Debian APT-HTTP/1.3 (0.8.16~exp12ubuntu10.21)"`)
 	f.Add(`127.0.0.1 - admin [04/Nov/2018:12:30:45 +0000] "POST /api HTTP/2.0" 201 512 "https://example.com" "curl/7.64.1"`)
+	f.Add(`127.0.0.1 - - [01/Jan/2000:00:00:00 +0000] "" 0 0 "" ""`)
 	f.Add(`invalid log line that should not crash`)
 	f.Add(``)
 

--- a/nginx/fuzz_test.go
+++ b/nginx/fuzz_test.go
@@ -1,0 +1,71 @@
+package nginx
+
+import (
+	"testing"
+
+	"github.com/mintance/nginx-clickhouse/config"
+)
+
+func FuzzParseField(f *testing.F) {
+	// Seed corpus with representative field names and values.
+	seeds := []struct {
+		key, value string
+	}{
+		{"time_local", "04/Nov/2018:12:30:45 +0000"},
+		{"status", "200"},
+		{"status", "abc"},
+		{"body_bytes_sent", "1024"},
+		{"request_time", "0.123"},
+		{"request_time", "not-a-float"},
+		{"remote_addr", "192.168.1.1"},
+		{"request", "GET /index.html HTTP/1.1"},
+		{"http_user_agent", "Mozilla/5.0"},
+		{"unknown_field", "some_value"},
+		{"bytes_sent", ""},
+		{"msec", "1541234567.890"},
+	}
+	for _, s := range seeds {
+		f.Add(s.key, s.value)
+	}
+
+	f.Fuzz(func(t *testing.T, key, value string) {
+		// ParseField must not panic on any input.
+		_ = ParseField(key, value)
+	})
+}
+
+func FuzzParseLogs(f *testing.F) {
+	f.Add(`93.180.71.3 - - [17/May/2015:08:05:32 +0000] "GET /downloads/product_1 HTTP/1.1" 304 0 "-" "Debian APT-HTTP/1.3 (0.8.16~exp12ubuntu10.21)"`)
+	f.Add(`127.0.0.1 - admin [04/Nov/2018:12:30:45 +0000] "POST /api HTTP/2.0" 201 512 "https://example.com" "curl/7.64.1"`)
+	f.Add(`invalid log line that should not crash`)
+	f.Add(``)
+
+	cfg := &config.Config{}
+	cfg.Nginx.LogType = "main"
+	cfg.Nginx.LogFormat = `$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"`
+
+	parser, err := NewParser(cfg)
+	if err != nil {
+		f.Fatalf("failed to create parser: %v", err)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		// ParseLogs must not panic on any input.
+		_ = ParseLogs(parser, []string{line})
+	})
+}
+
+func FuzzParseJSONLogs(f *testing.F) {
+	f.Add(`{"remote_addr":"127.0.0.1","status":"200","request":"GET / HTTP/1.1"}`)
+	f.Add(`{"status":404,"request_time":0.123,"body_bytes_sent":1024}`)
+	f.Add(`{"nested":{"key":"value"},"array":[1,2,3]}`)
+	f.Add(`not json at all`)
+	f.Add(``)
+	f.Add(`{}`)
+	f.Add(`{"bool_field":true,"null_field":null}`)
+
+	f.Fuzz(func(t *testing.T, line string) {
+		// ParseJSONLogs must not panic on any input.
+		_ = ParseJSONLogs([]string{line})
+	})
+}


### PR DESCRIPTION
Addresses low-scoring OpenSSF Scorecard checks (currently 3.6/10):

  - **Security-Policy (0→10):** Add `SECURITY.md` with vulnerability reporting instructions
  - **SAST (0→10):** Add `govulncheck` CI job to detect known vulnerabilities on every PR
  - **Fuzzing (0→10):** Add native Go fuzz tests for `ParseField`, `ParseLogs`, `ParseJSONLogs`, and `filter.Chain.Apply` with a CI job running each for 30s

## Test plan

  - [x] `go test ./... -race` passes locally
  - [x] Fuzz tests run without panics (`go test ./nginx/ -fuzz=FuzzParseField -fuzztime=10s`)
  - [x] CI `sast` job passes (govulncheck finds no vulnerabilities)
  - [x] CI `fuzz` job completes within timeout