### PR TITLE
docs: add RequestTime column to schema, log_format, and column mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ clickhouse:
     Request: request
     Status: status
     BytesSent: bytes_sent
+    RequestTime: request_time
     HttpReferer: http_referer
     HttpUserAgent: http_user_agent
     # RefererDomain: _referrer_domain   # enrichment: domain from http_referer
@@ -204,7 +205,7 @@ clickhouse:
 nginx:
   log_type: main
   log_format_type: text        # "text" (default) or "json"
-  log_format: '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"'
+  log_format: '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent" $request_time'
 ```
 
 ## NGINX Setup
@@ -215,7 +216,7 @@ In `/etc/nginx/nginx.conf`:
 
 ```nginx
 http {
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"';
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent" $request_time';
 }
 ```
 
@@ -274,6 +275,7 @@ CREATE TABLE metrics.nginx (
     Request       String      CODEC(ZSTD(1)),
     Status        UInt16,
     BytesSent     UInt64      CODEC(Delta(4), ZSTD(1)),
+    RequestTime   Float32     CODEC(Gorilla, ZSTD(1)),    -- Gorilla codec on slowly-varying floats
     HttpReferer   String      CODEC(ZSTD(1)),
     HttpUserAgent String      CODEC(ZSTD(1)),
     Hostname      LowCardinality(String),                 -- few distinct values

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -57,6 +57,7 @@ clickhouse:
    Request: request
    Status: status
    BytesSent: bytes_sent
+   RequestTime: request_time
    HttpReferer: http_referer
    HttpUserAgent: http_user_agent
    # Hostname: _hostname           # enrichment: from settings.enrichments.hostname
@@ -77,4 +78,4 @@ clickhouse:
 nginx:
   log_type: main
   # log_format_type: json    # "text" (default) or "json"
-  log_format: $remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"
+  log_format: $remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent" $request_time


### PR DESCRIPTION
Aligns README and config-sample.yml with grafana/dashboard.json, which already queries a RequestTime column for avg/p95/p99 latency panels and the slow-requests table. Following the README setup previously produced a missing-column error in those panels.

- README CREATE TABLE: add RequestTime Float32 CODEC(Gorilla, ZSTD(1))
- README + config-sample.yml log_format: append $request_time
- README + config-sample.yml columns: add RequestTime: request_time