### PR TITLE
fix: bump Go to 1.26.3 to patch net/http2 stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mintance/nginx-clickhouse
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.45.0


### PR DESCRIPTION
govulncheck flagged two stdlib vulnerabilities reachable from this code:

- GO-2026-4971 (net): Panic in Dial/LookupPort on NUL byte (Windows). Reachable via clickhouse Ping (net.Dialer.DialContext) and the /healthz HTTP listener (net.Listen).
- GO-2026-4918 (net/http2): Infinite loop on bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 (vendored from x/net). Reachable via the ClickHouse HTTP transport paths.

Both are fixed in Go 1.26.3. CI workflows already read go-version-file from go.mod, so this single bump propagates everywhere except the Dockerfile, which uses the floating golang:1.26-alpine tag and resolves to the latest patch automatically. govulncheck now reports no vulnerabilities; all 118 unit tests pass under 1.26.3.